### PR TITLE
Add derive macro to faciliate elements creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,7 @@ dependencies = [
 name = "fynix_macros"
 version = "0.1.0"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,6 +593,7 @@ name = "fynix"
 version = "0.1.0"
 dependencies = [
  "field_path",
+ "fynix_macros",
  "hashbrown 0.16.1",
  "imaging",
  "rectree",
@@ -612,6 +613,15 @@ dependencies = [
  "typeslot",
  "vello",
  "winit",
+]
+
+[[package]]
+name = "fynix_macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/voxell-tech/fynix"
 
 [workspace.dependencies]
 fynix = { path = "crates/fynix" }
+fynix_macros = { path = "crates/fynix_macros" }
 fynix_elements = { path = "crates/fynix_elements" }
 
 rectree = { git = "https://github.com/voxell-tech/rectree", rev = "08ddf2a" }

--- a/crates/fynix/Cargo.toml
+++ b/crates/fynix/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+fynix_macros.workspace = true
 rectree.workspace = true
 hashbrown.workspace = true
 field_path.workspace = true

--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -103,23 +103,17 @@ mod tests {
 
     use field_path::field_accessor;
     use rectree::{Constraint, NodeContext, Size, Vec2};
-    use typeslot::TypeSlot;
 
-    use crate::element::{ElementGroup, ElementNodes};
+    use crate::element::ElementNodes;
 
     use super::*;
 
-    #[derive(Default, Clone, TypeSlot)]
-    #[slot(ElementGroup)]
+    #[derive(Element, Default, Clone)]
     struct Label {
         pub text: String,
     }
 
     impl Element for Label {
-        fn new() -> Self {
-            Self::default()
-        }
-
         fn build(
             &self,
             _id: &ElementId,
@@ -133,9 +127,9 @@ mod tests {
         }
     }
 
-    #[derive(Default, Clone, TypeSlot)]
-    #[slot(ElementGroup)]
+    #[derive(Element, Default, Clone)]
     struct Vertical {
+        #[children]
         children: Vec<ElementId>,
     }
 
@@ -146,10 +140,6 @@ mod tests {
     }
 
     impl Element for Vertical {
-        fn new() -> Self {
-            Self::default()
-        }
-
         fn build(
             &self,
             _id: &ElementId,

--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -104,6 +104,7 @@ mod tests {
     use field_path::field_accessor;
     use rectree::{Constraint, NodeContext, Size, Vec2};
 
+    use crate::element::ElementBuild;
     use crate::element::ElementNodes;
 
     use super::*;
@@ -113,16 +114,13 @@ mod tests {
         pub text: String,
     }
 
-    impl Element for Label {
+    impl ElementBuild for Label {
         fn build(
             &self,
             _id: &ElementId,
             constraint: Constraint,
             _nodes: &mut ElementNodes,
-        ) -> rectree::Size
-        where
-            Self: Sized,
-        {
+        ) -> rectree::Size {
             constraint.min
         }
     }
@@ -139,16 +137,13 @@ mod tests {
         }
     }
 
-    impl Element for Vertical {
+    impl ElementBuild for Vertical {
         fn build(
             &self,
             _id: &ElementId,
             constraint: Constraint,
             nodes: &mut ElementNodes,
-        ) -> Size
-        where
-            Self: Sized,
-        {
+        ) -> Size {
             let mut size = Size::ZERO;
 
             for child in self.children.iter() {

--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -104,8 +104,7 @@ mod tests {
     use field_path::field_accessor;
     use rectree::{Constraint, NodeContext, Size, Vec2};
 
-    use crate::element::ElementBuild;
-    use crate::element::ElementNodes;
+    use crate::element::{ElementBuild, ElementNodes};
 
     use super::*;
 
@@ -120,7 +119,7 @@ mod tests {
             _id: &ElementId,
             constraint: Constraint,
             _nodes: &mut ElementNodes,
-        ) -> rectree::Size {
+        ) -> Size {
             constraint.min
         }
     }

--- a/crates/fynix/src/element.rs
+++ b/crates/fynix/src/element.rs
@@ -19,8 +19,8 @@ pub struct ElementGroup;
 
 /// Constructs a default (unstyled) instance of an element.
 ///
-/// Implement this alongside [`Element`]. Styles are applied
-/// immediately after construction by the build context.
+/// Derived by `#[derive(Element)]` - calls `Default::default()` unless
+/// overridden with `#[element(new = my_fn)]`.
 pub trait ElementNew {
     fn new() -> Self
     where
@@ -29,8 +29,8 @@ pub trait ElementNew {
 
 /// Enumerates the children of an element.
 ///
-/// The default implementation yields no children, suitable
-/// for leaf elements.
+/// Derived by `#[derive(Element)]` - iterates the field tagged `#[children]`,
+/// or the fn given in `#[element(children = my_fn)]`. Defaults to no children.
 pub trait ElementChildren {
     fn children(&self) -> impl IntoIterator<Item = &ElementId>
     where
@@ -42,13 +42,11 @@ pub trait ElementChildren {
 
 /// Trait for element types.
 ///
-/// Implement this for any type you want to add to the
-/// element tree via
+/// Implement this for any type you want to add to the element tree via
 /// [`FynixCtx::add`](crate::ctx::FynixCtx::add).
 ///
-/// Use `#[derive(Element)]` to derive [`ElementNew`] and
-/// [`ElementChildren`] automatically; implement `build`
-/// manually.
+/// Use `#[derive(Element)]` to derive [`ElementNew`] and [`ElementChildren`]
+/// automatically; implement `build` manually.
 pub trait Element:
     ElementNew + ElementChildren + TypeSlot<ElementGroup> + 'static
 {

--- a/crates/fynix/src/element.rs
+++ b/crates/fynix/src/element.rs
@@ -17,28 +17,41 @@ pub mod table;
 #[derive(SlotGroup)]
 pub struct ElementGroup;
 
-/// Trait for element types.
+/// Constructs a default (unstyled) instance of an element.
 ///
-/// Implement this for any type you want to add to the
-/// element tree via
-/// [`FynixCtx::add`](crate::ctx::FynixCtx::add). The single
-/// required method, `new`, must return a default (unstyled)
-/// instance.
-///
-/// Styles are applied immediately after construction by the
-/// build context.
-pub trait Element: TypeSlot<ElementGroup> + 'static {
+/// Implement this alongside [`Element`]. Styles are applied
+/// immediately after construction by the build context.
+pub trait ElementNew {
     fn new() -> Self
     where
         Self: Sized;
+}
 
+/// Enumerates the children of an element.
+///
+/// The default implementation yields no children, suitable
+/// for leaf elements.
+pub trait ElementChildren {
     fn children(&self) -> impl IntoIterator<Item = &ElementId>
     where
         Self: Sized,
     {
         []
     }
+}
 
+/// Trait for element types.
+///
+/// Implement this for any type you want to add to the
+/// element tree via
+/// [`FynixCtx::add`](crate::ctx::FynixCtx::add).
+///
+/// Use `#[derive(Element)]` to derive [`ElementNew`] and
+/// [`ElementChildren`] automatically; implement `build`
+/// manually.
+pub trait Element:
+    ElementNew + ElementChildren + TypeSlot<ElementGroup> + 'static
+{
     fn constrain(&self, parent_constraint: Constraint) -> Constraint {
         parent_constraint
     }

--- a/crates/fynix/src/element.rs
+++ b/crates/fynix/src/element.rs
@@ -40,16 +40,10 @@ pub trait ElementChildren {
     }
 }
 
-/// Trait for element types.
+/// Layout and rendering protocol for element types.
 ///
-/// Implement this for any type you want to add to the element tree via
-/// [`FynixCtx::add`](crate::ctx::FynixCtx::add).
-///
-/// Use `#[derive(Element)]` to derive [`ElementNew`] and [`ElementChildren`]
-/// automatically; implement `build` manually.
-pub trait Element:
-    ElementNew + ElementChildren + TypeSlot<ElementGroup> + 'static
-{
+/// Implement this manually alongside `#[derive(Element)]`.
+pub trait ElementBuild {
     fn constrain(&self, parent_constraint: Constraint) -> Constraint {
         parent_constraint
     }
@@ -83,6 +77,18 @@ pub trait Element:
         metas: &ElementMetas,
     ) {
     }
+}
+
+/// Marker trait for element types. Use `#[derive(Element)]` to implement
+/// this alongside [`ElementNew`] and [`ElementChildren`] automatically.
+/// Implement [`ElementBuild`] manually.
+pub trait Element:
+    ElementNew
+    + ElementChildren
+    + ElementBuild
+    + TypeSlot<ElementGroup>
+    + 'static
+{
 }
 
 /// Type-erased storage for all element instances.
@@ -172,7 +178,7 @@ impl Elements {
     /// Renders the subtree rooted at `id` into `sink`.
     ///
     /// Each element's own visual layer is painted via
-    /// [`Element::render`] before its children are visited,
+    /// [`ElementBuild::render`] before its children are visited,
     /// so parents always draw behind their children.
     ///
     /// Layout must be complete before calling this -

--- a/crates/fynix/src/element.rs
+++ b/crates/fynix/src/element.rs
@@ -8,12 +8,71 @@ use crate::element::table::ElementTable;
 use crate::id::{GenId, IdGenerator};
 use crate::resource::Resources;
 
+pub use fynix_macros::{Element, ElementSlot};
+
 pub mod meta;
 pub mod table;
 
 /// Marker type for the element slot group.
 #[derive(SlotGroup)]
 pub struct ElementGroup;
+
+/// Trait for element types.
+///
+/// Implement this for any type you want to add to the
+/// element tree via
+/// [`FynixCtx::add`](crate::ctx::FynixCtx::add). The single
+/// required method, `new`, must return a default (unstyled)
+/// instance.
+///
+/// Styles are applied immediately after construction by the
+/// build context.
+pub trait Element: TypeSlot<ElementGroup> + 'static {
+    fn new() -> Self
+    where
+        Self: Sized;
+
+    fn children(&self) -> impl IntoIterator<Item = &ElementId>
+    where
+        Self: Sized,
+    {
+        []
+    }
+
+    fn constrain(&self, parent_constraint: Constraint) -> Constraint {
+        parent_constraint
+    }
+
+    fn build(
+        &self,
+        id: &ElementId,
+        constraint: Constraint,
+        nodes: &mut ElementNodes,
+    ) -> Size;
+
+    /// Paints the element's own visual layer into `painter`.
+    ///
+    /// The element's world-space position and layout size can
+    /// be read from `metas` using `id`. Both are set by the
+    /// layout pass and are safe to use for rendering
+    /// coordinates.
+    ///
+    /// Child elements are rendered by the tree walker after
+    /// this method returns - do not recurse into children
+    /// here.
+    ///
+    /// The default implementation is a no-op, suitable for
+    /// purely structural elements that have no visual of
+    /// their own.
+    #[expect(unused_variables)]
+    fn render(
+        &self,
+        id: &ElementId,
+        painter: &mut dyn PaintSink,
+        metas: &ElementMetas,
+    ) {
+    }
+}
 
 /// Type-erased storage for all element instances.
 ///
@@ -276,63 +335,6 @@ impl<'a> Rectree for ElementTree<'a> {
                     .unwrap_or_default()
             })
             .unwrap_or(Size::ZERO)
-    }
-}
-
-/// Trait for element types.
-///
-/// Implement this for any type you want to add to the
-/// element tree via
-/// [`FynixCtx::add`](crate::ctx::FynixCtx::add). The single
-/// required method, `new`, must return a default (unstyled)
-/// instance.
-///
-/// Styles are applied immediately after construction by the
-/// build context.
-pub trait Element: TypeSlot<ElementGroup> + 'static {
-    fn new() -> Self
-    where
-        Self: Sized;
-
-    fn children(&self) -> impl IntoIterator<Item = &ElementId>
-    where
-        Self: Sized,
-    {
-        []
-    }
-
-    fn constrain(&self, parent_constraint: Constraint) -> Constraint {
-        parent_constraint
-    }
-
-    fn build(
-        &self,
-        id: &ElementId,
-        constraint: Constraint,
-        nodes: &mut ElementNodes,
-    ) -> Size;
-
-    /// Paints the element's own visual layer into `painter`.
-    ///
-    /// The element's world-space position and layout size can
-    /// be read from `metas` using `id`. Both are set by the
-    /// layout pass and are safe to use for rendering
-    /// coordinates.
-    ///
-    /// Child elements are rendered by the tree walker after
-    /// this method returns - do not recurse into children
-    /// here.
-    ///
-    /// The default implementation is a no-op, suitable for
-    /// purely structural elements that have no visual of
-    /// their own.
-    #[expect(unused_variables)]
-    fn render(
-        &self,
-        id: &ElementId,
-        painter: &mut dyn PaintSink,
-        metas: &ElementMetas,
-    ) {
     }
 }
 

--- a/crates/fynix/src/element/meta.rs
+++ b/crates/fynix/src/element/meta.rs
@@ -155,12 +155,14 @@ pub fn get_dyn_element<'a, E: Element>(
 
 /// Visits each child of an element by calling `f` for every
 /// [`ElementId`] the element yields from
-/// [`Element::children`].
+/// [`ElementChildren::children`].
 ///
 /// Using a visitor avoids the need to name the concrete
-/// iterator type returned by [`Element::children`], which
+/// iterator type returned by [`ElementChildren::children`], which
 /// differs per `E` and cannot be expressed in a
 /// function-pointer signature.
+///
+/// [`ElementChildren::children`]: super::ElementChildren::children
 pub type ChildrenElementFn = fn(
     table: &ElementTable,
     id: &ElementId,

--- a/crates/fynix/src/id.rs
+++ b/crates/fynix/src/id.rs
@@ -34,6 +34,12 @@ impl<T> GenId<T> {
     }
 }
 
+impl<T> Default for GenId<T> {
+    fn default() -> Self {
+        Self::PLACEHOLDER
+    }
+}
+
 impl<T> Display for GenId<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{}v{}", self.id, self.generation)

--- a/crates/fynix/src/id.rs
+++ b/crates/fynix/src/id.rs
@@ -1,6 +1,7 @@
 use core::fmt::{Debug, Display, Formatter, Result};
 use core::hash::Hash;
 use core::marker::PhantomData;
+use core::slice::Iter;
 
 use alloc::vec::Vec;
 
@@ -92,6 +93,15 @@ impl<T> PartialOrd for GenId<T> {
 }
 
 impl<T> Copy for GenId<T> {}
+
+impl<'a, T> IntoIterator for &'a GenId<T> {
+    type Item = &'a GenId<T>;
+    type IntoIter = Iter<'a, GenId<T>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        core::slice::from_ref(self).iter()
+    }
+}
 
 impl<T> Clone for GenId<T> {
     fn clone(&self) -> Self {

--- a/crates/fynix/src/id.rs
+++ b/crates/fynix/src/id.rs
@@ -1,7 +1,6 @@
 use core::fmt::{Debug, Display, Formatter, Result};
 use core::hash::Hash;
 use core::marker::PhantomData;
-use core::slice::Iter;
 
 use alloc::vec::Vec;
 
@@ -32,12 +31,6 @@ impl<T> GenId<T> {
     const fn next_generation(mut self) -> Self {
         self.generation = self.generation.wrapping_add(1);
         self
-    }
-}
-
-impl<T> Default for GenId<T> {
-    fn default() -> Self {
-        Self::PLACEHOLDER
     }
 }
 
@@ -93,15 +86,6 @@ impl<T> PartialOrd for GenId<T> {
 }
 
 impl<T> Copy for GenId<T> {}
-
-impl<'a, T> IntoIterator for &'a GenId<T> {
-    type Item = &'a GenId<T>;
-    type IntoIter = Iter<'a, GenId<T>>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        core::slice::from_ref(self).iter()
-    }
-}
 
 impl<T> Clone for GenId<T> {
     fn clone(&self) -> Self {

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -15,6 +15,7 @@ use crate::style::{StyleId, Styles};
 
 pub use imaging;
 pub use rectree;
+pub use typeslot;
 
 pub mod ctx;
 pub mod element;

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -13,7 +13,7 @@ use crate::element::{ElementGroup, ElementId, Elements};
 use crate::resource::Resources;
 use crate::style::{StyleId, Styles};
 
-pub use fynix_macros::ElementSlot;
+pub use fynix_macros::{Element, ElementSlot};
 pub use imaging;
 pub use rectree;
 

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -13,6 +13,7 @@ use crate::element::{ElementGroup, ElementId, Elements};
 use crate::resource::Resources;
 use crate::style::{StyleId, Styles};
 
+pub use fynix_macros::ElementSlot;
 pub use imaging;
 pub use rectree;
 

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -13,7 +13,6 @@ use crate::element::{ElementGroup, ElementId, Elements};
 use crate::resource::Resources;
 use crate::style::{StyleId, Styles};
 
-pub use fynix_macros::{Element, ElementSlot};
 pub use imaging;
 pub use rectree;
 

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -28,7 +28,7 @@ mod id;
 /// Initializes the Fynix framework.
 ///
 /// Must be called before any element is added to a [`Fynix`]
-/// instance. Safe to call more than once — subsequent calls
+/// instance. Safe to call more than once - subsequent calls
 /// are no-ops.
 pub fn init() {
     static INITIALIZED: AtomicBool = AtomicBool::new(false);

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -7,7 +7,7 @@ use alloc::vec::Vec;
 
 use fynix::Fynix;
 use fynix::element::meta::ElementMetas;
-use fynix::element::{Element, ElementId, ElementNodes, ElementSlot};
+use fynix::element::{Element, ElementId, ElementNodes};
 use fynix::imaging::kurbo::Affine;
 use fynix::imaging::peniko::{Brush, BrushRef, Color, Fill, Style};
 use fynix::imaging::record::{Glyph, Scene, replay_transformed};
@@ -18,9 +18,11 @@ use parley::{
     Alignment, AlignmentOptions, FontStyle, PositionedLayoutItem,
 };
 use parley::{FontContext, LayoutContext};
-#[derive(ElementSlot, Default, Debug, Clone, Copy)]
+
+#[derive(Element, Default, Debug, Clone, Copy)]
 pub struct WindowSize {
     pub size: Size,
+    #[children]
     child: Option<ElementId>,
 }
 
@@ -31,20 +33,6 @@ impl WindowSize {
 }
 
 impl Element for WindowSize {
-    fn new() -> Self
-    where
-        Self: Sized,
-    {
-        Self::default()
-    }
-
-    fn children(&self) -> impl IntoIterator<Item = &ElementId>
-    where
-        Self: Sized,
-    {
-        self.child.iter()
-    }
-
     fn constrain(
         &self,
         _parent_constraint: Constraint,
@@ -62,8 +50,9 @@ impl Element for WindowSize {
     }
 }
 
-#[derive(ElementSlot, Default, Debug, Clone)]
+#[derive(Element, Default, Debug, Clone)]
 pub struct Horizontal {
+    #[children]
     children: Vec<ElementId>,
 }
 
@@ -75,25 +64,6 @@ impl Horizontal {
 }
 
 impl Element for Horizontal {
-    fn new() -> Self
-    where
-        Self: Sized,
-    {
-        Self::default()
-    }
-
-    fn children(&self) -> impl IntoIterator<Item = &ElementId>
-    where
-        Self: Sized,
-    {
-        // TODO: Refer to this when creating the #[derive(Element)]
-        // macro. And remove it after that.
-
-        // Showcasing the generic way of doing it.
-        #[allow(clippy::into_iter_on_ref)]
-        (&self.children).into_iter()
-    }
-
     fn build(
         &self,
         _id: &ElementId,
@@ -114,8 +84,9 @@ impl Element for Horizontal {
     }
 }
 
-#[derive(ElementSlot, Default, Debug, Clone)]
+#[derive(Element, Default, Debug, Clone)]
 pub struct Vertical {
+    #[children]
     children: Vec<ElementId>,
 }
 
@@ -127,20 +98,6 @@ impl Vertical {
 }
 
 impl Element for Vertical {
-    fn new() -> Self
-    where
-        Self: Sized,
-    {
-        Self::default()
-    }
-
-    fn children(&self) -> impl IntoIterator<Item = &ElementId>
-    where
-        Self: Sized,
-    {
-        self.children.iter()
-    }
-
     fn build(
         &self,
         _id: &ElementId,
@@ -161,7 +118,7 @@ impl Element for Vertical {
     }
 }
 
-#[derive(ElementSlot, Debug, Clone)]
+#[derive(Element, Debug, Clone)]
 pub struct Label {
     pub text: String,
     pub fill: Brush,
@@ -170,11 +127,8 @@ pub struct Label {
     pub alignment: Alignment,
 }
 
-impl Element for Label {
-    fn new() -> Self
-    where
-        Self: Sized,
-    {
+impl Default for Label {
+    fn default() -> Self {
         Self {
             text: String::new(),
             fill: Brush::Solid(Color::WHITE),
@@ -183,7 +137,9 @@ impl Element for Label {
             alignment: Default::default(),
         }
     }
+}
 
+impl Element for Label {
     fn build(
         &self,
         id: &ElementId,

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -7,7 +7,9 @@ use alloc::vec::Vec;
 
 use fynix::Fynix;
 use fynix::element::meta::ElementMetas;
-use fynix::element::{Element, ElementId, ElementNodes};
+use fynix::element::{
+    Element, ElementBuild, ElementId, ElementNodes,
+};
 use fynix::imaging::kurbo::Affine;
 use fynix::imaging::peniko::{Brush, BrushRef, Color, Fill, Style};
 use fynix::imaging::record::{Glyph, Scene, replay_transformed};
@@ -32,7 +34,7 @@ impl WindowSize {
     }
 }
 
-impl Element for WindowSize {
+impl ElementBuild for WindowSize {
     fn constrain(
         &self,
         _parent_constraint: Constraint,
@@ -63,7 +65,7 @@ impl Horizontal {
     }
 }
 
-impl Element for Horizontal {
+impl ElementBuild for Horizontal {
     fn build(
         &self,
         _id: &ElementId,
@@ -97,7 +99,7 @@ impl Vertical {
     }
 }
 
-impl Element for Vertical {
+impl ElementBuild for Vertical {
     fn build(
         &self,
         _id: &ElementId,
@@ -139,7 +141,7 @@ impl Default for Label {
     }
 }
 
-impl Element for Label {
+impl ElementBuild for Label {
     fn build(
         &self,
         id: &ElementId,

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -5,10 +5,9 @@ extern crate alloc;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use fynix::ElementSlot;
 use fynix::Fynix;
 use fynix::element::meta::ElementMetas;
-use fynix::element::{Element, ElementId, ElementNodes};
+use fynix::element::{Element, ElementId, ElementNodes, ElementSlot};
 use fynix::imaging::kurbo::Affine;
 use fynix::imaging::peniko::{Brush, BrushRef, Color, Fill, Style};
 use fynix::imaging::record::{Glyph, Scene, replay_transformed};

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -5,11 +5,10 @@ extern crate alloc;
 use alloc::string::String;
 use alloc::vec::Vec;
 
+use fynix::ElementSlot;
 use fynix::Fynix;
 use fynix::element::meta::ElementMetas;
-use fynix::element::{
-    Element, ElementGroup, ElementId, ElementNodes,
-};
+use fynix::element::{Element, ElementId, ElementNodes};
 use fynix::imaging::kurbo::Affine;
 use fynix::imaging::peniko::{Brush, BrushRef, Color, Fill, Style};
 use fynix::imaging::record::{Glyph, Scene, replay_transformed};
@@ -20,10 +19,7 @@ use parley::{
     Alignment, AlignmentOptions, FontStyle, PositionedLayoutItem,
 };
 use parley::{FontContext, LayoutContext};
-use typeslot::TypeSlot;
-
-#[derive(Default, Debug, Clone, Copy, TypeSlot)]
-#[slot(ElementGroup)]
+#[derive(ElementSlot, Default, Debug, Clone, Copy)]
 pub struct WindowSize {
     pub size: Size,
     child: Option<ElementId>,
@@ -67,8 +63,7 @@ impl Element for WindowSize {
     }
 }
 
-#[derive(Default, Debug, Clone, TypeSlot)]
-#[slot(ElementGroup)]
+#[derive(ElementSlot, Default, Debug, Clone)]
 pub struct Horizontal {
     children: Vec<ElementId>,
 }
@@ -120,8 +115,7 @@ impl Element for Horizontal {
     }
 }
 
-#[derive(Default, Debug, Clone, TypeSlot)]
-#[slot(ElementGroup)]
+#[derive(ElementSlot, Default, Debug, Clone)]
 pub struct Vertical {
     children: Vec<ElementId>,
 }
@@ -168,8 +162,7 @@ impl Element for Vertical {
     }
 }
 
-#[derive(Debug, Clone, TypeSlot)]
-#[slot(ElementGroup)]
+#[derive(ElementSlot, Debug, Clone)]
 pub struct Label {
     pub text: String,
     pub fill: Brush,

--- a/crates/fynix_macros/Cargo.toml
+++ b/crates/fynix_macros/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 proc-macro = true
 
 [dependencies]
+proc-macro-crate = "3"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["derive"] }

--- a/crates/fynix_macros/Cargo.toml
+++ b/crates/fynix_macros/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "fynix_macros"
+description = "Proc-macro derives for the Fynix UI framework."
+keywords = ["ui", "gui", "fynix", "macro"]
+categories = ["gui"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["derive"] }

--- a/crates/fynix_macros/src/lib.rs
+++ b/crates/fynix_macros/src/lib.rs
@@ -1,0 +1,53 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::DeriveInput;
+use syn::parse_macro_input;
+
+/// Derives `typeslot::TypeSlot<fynix::element::ElementGroup>`
+/// for the annotated type.
+///
+/// Equivalent to writing:
+///
+/// ```ignore
+/// #[derive(::typeslot::TypeSlot)]
+/// #[slot(::fynix::element::ElementGroup)]
+/// ```
+#[proc_macro_derive(ElementSlot)]
+pub fn derive_element_slot(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+
+    quote! {
+        const _: () = {
+            static __SLOT: ::typeslot::AtomicSlot =
+                ::typeslot::AtomicSlot::new();
+
+            impl ::typeslot::TypeSlot<
+                ::fynix::element::ElementGroup,
+            > for #name {
+                #[inline]
+                fn try_slot() -> ::core::option::Option<usize> {
+                    __SLOT.get()
+                }
+
+                #[inline]
+                fn dyn_try_slot(
+                    &self,
+                ) -> ::core::option::Option<usize> {
+                    __SLOT.get()
+                }
+            }
+
+            ::typeslot::inventory::submit! {
+                ::typeslot::TypeSlotEntry {
+                    type_id: ::core::any::TypeId::of::<#name>(),
+                    group_id: ::core::any::TypeId::of::<
+                        ::fynix::element::ElementGroup,
+                    >(),
+                    slot: &__SLOT,
+                }
+            }
+        };
+    }
+    .into()
+}

--- a/crates/fynix_macros/src/lib.rs
+++ b/crates/fynix_macros/src/lib.rs
@@ -107,46 +107,7 @@ fn parse_element_attrs(
     })
 }
 
-/// Derives `ElementNew` and `ElementChildren` for the annotated
-/// struct. Also derives `ElementSlot` — no need to add it
-/// separately.
-///
-/// ## `ElementNew`
-///
-/// By default calls `Default::default()`, requiring the struct to
-/// also `#[derive(Default)]`. Override with:
-///
-/// ```ignore
-/// #[element(new = my_constructor_fn)]
-/// ```
-///
-/// where `my_constructor_fn` is a `fn() -> Self`.
-///
-/// ## `ElementChildren`
-///
-/// Mark one field `#[children]` for the standard iterator impl:
-///
-/// ```ignore
-/// #[derive(Element, Default)]
-/// pub struct MyElement {
-///     #[children]
-///     child: ElementId,  // or Option<ElementId>, or Vec<ElementId>
-/// }
-/// ```
-///
-/// Or override entirely with:
-///
-/// ```ignore
-/// #[element(children = my_children_fn)]
-/// ```
-///
-/// where `my_children_fn` is a `fn(&Self) -> impl IntoIterator<Item = &ElementId>`.
-///
-/// If neither is present the default (no children) is used.
-///
-/// ## `build`
-///
-/// Not generated — implement `Element::build` manually.
+/// Derives `ElementNew`, `ElementChildren`, and `ElementSlot` for the annotated struct.
 #[proc_macro_derive(Element, attributes(children, element))]
 pub fn derive_element(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/crates/fynix_macros/src/lib.rs
+++ b/crates/fynix_macros/src/lib.rs
@@ -7,6 +7,7 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::Data;
 use syn::DeriveInput;
+use syn::Expr;
 use syn::Fields;
 use syn::parse_macro_input;
 
@@ -75,31 +76,87 @@ pub fn derive_element_slot(input: TokenStream) -> TokenStream {
     element_slot_tokens(&input.ident, &fynix).into()
 }
 
-/// Derives a default `fynix::element::Element` implementation
-/// for a single-child element.
+struct ElementAttrs {
+    new_fn: Option<Expr>,
+    children_fn: Option<Expr>,
+}
+
+fn parse_element_attrs(
+    attrs: &[syn::Attribute],
+) -> syn::Result<ElementAttrs> {
+    let mut new_fn = None;
+    let mut children_fn = None;
+
+    for attr in attrs {
+        if attr.path().is_ident("element") {
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("new") {
+                    new_fn = Some(meta.value()?.parse::<Expr>()?);
+                } else if meta.path.is_ident("children") {
+                    children_fn =
+                        Some(meta.value()?.parse::<Expr>()?);
+                }
+                Ok(())
+            })?;
+        }
+    }
+
+    Ok(ElementAttrs {
+        new_fn,
+        children_fn,
+    })
+}
+
+/// Derives `ElementNew` and `ElementChildren` for the annotated
+/// struct. Also derives `ElementSlot` — no need to add it
+/// separately.
 ///
-/// Also derives `ElementSlot` - no need to add it separately.
+/// ## `ElementNew`
 ///
-/// The struct must have exactly one field marked `#[child]`,
-/// typed as `Option<ElementId>`. The generated impl:
+/// By default calls `Default::default()`, requiring the struct to
+/// also `#[derive(Default)]`. Override with:
 ///
-/// - `new` - constructs via `Default::default`.
-/// - `children` - yields the `#[child]` field.
-/// - `build` - returns the child's computed size, or
-///   `Size::ZERO` when no child is set.
+/// ```ignore
+/// #[element(new = my_constructor_fn)]
+/// ```
+///
+/// where `my_constructor_fn` is a `fn() -> Self`.
+///
+/// ## `ElementChildren`
+///
+/// Mark one field `#[children]` for the standard iterator impl:
 ///
 /// ```ignore
 /// #[derive(Element, Default)]
 /// pub struct MyElement {
-///     #[child]
-///     child: Option<ElementId>,
+///     #[children]
+///     child: ElementId,  // or Option<ElementId>, or Vec<ElementId>
 /// }
 /// ```
-#[proc_macro_derive(Element, attributes(child))]
+///
+/// Or override entirely with:
+///
+/// ```ignore
+/// #[element(children = my_children_fn)]
+/// ```
+///
+/// where `my_children_fn` is a `fn(&Self) -> impl IntoIterator<Item = &ElementId>`.
+///
+/// If neither is present the default (no children) is used.
+///
+/// ## `build`
+///
+/// Not generated — implement `Element::build` manually.
+#[proc_macro_derive(Element, attributes(children, element))]
 pub fn derive_element(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
     let fynix = fynix_crate();
+
+    let attrs = match parse_element_attrs(&input.attrs) {
+        Ok(a) => a,
+        Err(e) => return e.to_compile_error().into(),
+    };
 
     let fields = match &input.data {
         Data::Struct(s) => &s.fields,
@@ -125,74 +182,89 @@ pub fn derive_element(input: TokenStream) -> TokenStream {
         }
     };
 
-    let child_fields: Vec<_> = named
+    let children_fields: Vec<_> = named
         .iter()
         .filter(|f| {
-            f.attrs.iter().any(|a| a.path().is_ident("child"))
+            f.attrs.iter().any(|a| a.path().is_ident("children"))
         })
         .collect();
 
-    let child_field = match child_fields.len() {
-        1 => child_fields[0],
-        0 => {
-            return syn::Error::new_spanned(
-                name,
-                "#[derive(Element)] requires exactly one \
-                 #[child] field",
-            )
-            .to_compile_error()
-            .into();
-        }
-        _ => {
-            return syn::Error::new_spanned(
-                child_fields[1],
-                "#[derive(Element)] found multiple #[child] \
-                 fields; only one is allowed",
-            )
-            .to_compile_error()
-            .into();
-        }
+    if children_fields.len() > 1 {
+        return syn::Error::new_spanned(
+            children_fields[1],
+            "#[derive(Element)] found multiple #[children] \
+             fields; only one is allowed",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    let slot_tokens = element_slot_tokens(name, &fynix);
+
+    let new_impl = match &attrs.new_fn {
+        Some(f) => quote! {
+            impl #fynix::element::ElementNew for #name {
+                fn new() -> Self
+                where
+                    Self: ::core::marker::Sized,
+                {
+                    #f()
+                }
+            }
+        },
+        None => quote! {
+            impl #fynix::element::ElementNew for #name {
+                fn new() -> Self
+                where
+                    Self: ::core::marker::Sized,
+                {
+                    ::core::default::Default::default()
+                }
+            }
+        },
     };
 
-    let child_ident = child_field.ident.as_ref().unwrap();
-    let slot_tokens = element_slot_tokens(name, &fynix);
+    let children_impl = if let Some(f) = &attrs.children_fn {
+        Some(quote! {
+            impl #fynix::element::ElementChildren for #name {
+                fn children(
+                    &self,
+                ) -> impl ::core::iter::IntoIterator<
+                    Item = &(#fynix::element::ElementId),
+                >
+                where
+                    Self: ::core::marker::Sized,
+                {
+                    #f(self)
+                }
+            }
+        })
+    } else if let Some(field) = children_fields.first() {
+        let ident = field.ident.as_ref().unwrap();
+        Some(quote! {
+            impl #fynix::element::ElementChildren for #name {
+                fn children(
+                    &self,
+                ) -> impl ::core::iter::IntoIterator<
+                    Item = &(#fynix::element::ElementId),
+                >
+                where
+                    Self: ::core::marker::Sized,
+                {
+                    (&self.#ident).into_iter()
+                }
+            }
+        })
+    } else {
+        Some(quote! {
+            impl #fynix::element::ElementChildren for #name {}
+        })
+    };
 
     quote! {
         #slot_tokens
-
-        impl #fynix::element::Element for #name {
-            fn new() -> Self
-            where
-                Self: Sized,
-            {
-                ::core::default::Default::default()
-            }
-
-            fn children(
-                &self,
-            ) -> impl ::core::iter::IntoIterator<
-                Item = &(#fynix::element::ElementId),
-            >
-            where
-                Self: Sized,
-            {
-                (&self.#child_ident).into_iter()
-            }
-
-            fn build(
-                &self,
-                _id: &(#fynix::element::ElementId),
-                constraint: #fynix::rectree::Constraint,
-                nodes: &mut #fynix::element::ElementNodes,
-            ) -> #fynix::rectree::Size {
-                use #fynix::rectree::NodeContext as _;
-                (&self.#child_ident)
-                    .into_iter()
-                    .map(|c| nodes.get_size(c))
-                    .next()
-                    .unwrap_or(#fynix::rectree::Size::ZERO)
-            }
-        }
+        #new_impl
+        #children_impl
     }
     .into()
 }

--- a/crates/fynix_macros/src/lib.rs
+++ b/crates/fynix_macros/src/lib.rs
@@ -119,31 +119,26 @@ pub fn derive_element(input: TokenStream) -> TokenStream {
         Err(e) => return e.to_compile_error().into(),
     };
 
-    let fields = match &input.data {
-        Data::Struct(s) => &s.fields,
-        _ => {
-            return syn::Error::new_spanned(
-                name,
-                "#[derive(Element)] only supports structs",
-            )
-            .to_compile_error()
-            .into();
-        }
+    let Data::Struct(s) = &input.data else {
+        return syn::Error::new_spanned(
+            name,
+            "#[derive(Element)] only supports structs",
+        )
+        .to_compile_error()
+        .into();
     };
 
-    let named = match fields {
-        Fields::Named(f) => &f.named,
-        _ => {
-            return syn::Error::new_spanned(
-                name,
-                "#[derive(Element)] requires named fields",
-            )
-            .to_compile_error()
-            .into();
-        }
+    let Fields::Named(f) = &s.fields else {
+        return syn::Error::new_spanned(
+            name,
+            "#[derive(Element)] requires named fields",
+        )
+        .to_compile_error()
+        .into();
     };
 
-    let children_fields: Vec<_> = named
+    let children_fields: Vec<_> = f
+        .named
         .iter()
         .filter(|f| {
             f.attrs.iter().any(|a| a.path().is_ident("children"))
@@ -162,32 +157,39 @@ pub fn derive_element(input: TokenStream) -> TokenStream {
 
     let slot_tokens = element_slot_tokens(name, &fynix);
 
-    let new_impl = match &attrs.new_fn {
-        Some(f) => quote! {
-            impl #fynix::element::ElementNew for #name {
-                fn new() -> Self
-                where
-                    Self: ::core::marker::Sized,
-                {
-                    #f()
-                }
+    let new_body = attrs
+        .new_fn
+        .as_ref()
+        .map(|f| quote! { #f() })
+        .unwrap_or_else(
+            || quote! { ::core::default::Default::default() },
+        );
+
+    let new_impl = quote! {
+        impl #fynix::element::ElementNew for #name {
+            fn new() -> Self
+            where
+                Self: ::core::marker::Sized,
+            {
+                #new_body
             }
-        },
-        None => quote! {
-            impl #fynix::element::ElementNew for #name {
-                fn new() -> Self
-                where
-                    Self: ::core::marker::Sized,
-                {
-                    ::core::default::Default::default()
-                }
-            }
-        },
+        }
     };
 
-    let children_impl = if let Some(f) = &attrs.children_fn {
-        Some(quote! {
-            impl #fynix::element::ElementChildren for #name {
+    let children_body = attrs
+        .children_fn
+        .as_ref()
+        .map(|f| quote! { #f(self) })
+        .or_else(|| {
+            children_fields.first().map(|field| {
+                let ident = field.ident.as_ref().unwrap();
+                quote! { (&self.#ident).into_iter() }
+            })
+        });
+
+    let children_fn = children_body
+        .map(|body| {
+            quote! {
                 fn children(
                     &self,
                 ) -> impl ::core::iter::IntoIterator<
@@ -196,30 +198,16 @@ pub fn derive_element(input: TokenStream) -> TokenStream {
                 where
                     Self: ::core::marker::Sized,
                 {
-                    #f(self)
+                    #body
                 }
             }
         })
-    } else if let Some(field) = children_fields.first() {
-        let ident = field.ident.as_ref().unwrap();
-        Some(quote! {
-            impl #fynix::element::ElementChildren for #name {
-                fn children(
-                    &self,
-                ) -> impl ::core::iter::IntoIterator<
-                    Item = &(#fynix::element::ElementId),
-                >
-                where
-                    Self: ::core::marker::Sized,
-                {
-                    (&self.#ident).into_iter()
-                }
-            }
-        })
-    } else {
-        Some(quote! {
-            impl #fynix::element::ElementChildren for #name {}
-        })
+        .unwrap_or_default();
+
+    let children_impl = quote! {
+        impl #fynix::element::ElementChildren for #name {
+            #children_fn
+        }
     };
 
     quote! {

--- a/crates/fynix_macros/src/lib.rs
+++ b/crates/fynix_macros/src/lib.rs
@@ -1,20 +1,37 @@
 use proc_macro::TokenStream;
+use proc_macro_crate::FoundCrate;
+use proc_macro_crate::crate_name;
+use proc_macro2::Ident;
+use proc_macro2::Span;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::Data;
 use syn::DeriveInput;
 use syn::Fields;
-use syn::Ident;
 use syn::parse_macro_input;
 
-fn element_slot_tokens(name: &Ident) -> TokenStream2 {
+fn fynix_crate() -> TokenStream2 {
+    match crate_name("fynix") {
+        Ok(FoundCrate::Itself) => quote!(crate),
+        Ok(FoundCrate::Name(name)) => {
+            let ident = Ident::new(&name, Span::call_site());
+            quote!(::#ident)
+        }
+        Err(_) => quote!(::fynix),
+    }
+}
+
+fn element_slot_tokens(
+    name: &Ident,
+    fynix: &TokenStream2,
+) -> TokenStream2 {
     quote! {
         const _: () = {
-            static __SLOT: ::typeslot::AtomicSlot =
-                ::typeslot::AtomicSlot::new();
+            static __SLOT: #fynix::typeslot::AtomicSlot =
+                #fynix::typeslot::AtomicSlot::new();
 
-            impl ::typeslot::TypeSlot<
-                ::fynix::element::ElementGroup,
+            impl #fynix::typeslot::TypeSlot<
+                #fynix::element::ElementGroup,
             > for #name {
                 #[inline]
                 fn try_slot() -> ::core::option::Option<usize> {
@@ -29,11 +46,11 @@ fn element_slot_tokens(name: &Ident) -> TokenStream2 {
                 }
             }
 
-            ::typeslot::inventory::submit! {
-                ::typeslot::TypeSlotEntry {
+            #fynix::typeslot::inventory::submit! {
+                #fynix::typeslot::TypeSlotEntry {
                     type_id: ::core::any::TypeId::of::<#name>(),
                     group_id: ::core::any::TypeId::of::<
-                        ::fynix::element::ElementGroup,
+                        #fynix::element::ElementGroup,
                     >(),
                     slot: &__SLOT,
                 }
@@ -54,7 +71,8 @@ fn element_slot_tokens(name: &Ident) -> TokenStream2 {
 #[proc_macro_derive(ElementSlot)]
 pub fn derive_element_slot(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    element_slot_tokens(&input.ident).into()
+    let fynix = fynix_crate();
+    element_slot_tokens(&input.ident, &fynix).into()
 }
 
 /// Derives a default `fynix::element::Element` implementation
@@ -81,6 +99,7 @@ pub fn derive_element_slot(input: TokenStream) -> TokenStream {
 pub fn derive_element(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
+    let fynix = fynix_crate();
 
     let fields = match &input.data {
         Data::Struct(s) => &s.fields,
@@ -136,12 +155,12 @@ pub fn derive_element(input: TokenStream) -> TokenStream {
     };
 
     let child_ident = child_field.ident.as_ref().unwrap();
-    let slot_tokens = element_slot_tokens(name);
+    let slot_tokens = element_slot_tokens(name, &fynix);
 
     quote! {
         #slot_tokens
 
-        impl ::fynix::element::Element for #name {
+        impl #fynix::element::Element for #name {
             fn new() -> Self
             where
                 Self: Sized,
@@ -152,25 +171,26 @@ pub fn derive_element(input: TokenStream) -> TokenStream {
             fn children(
                 &self,
             ) -> impl ::core::iter::IntoIterator<
-                Item = &::fynix::element::ElementId,
+                Item = &(#fynix::element::ElementId),
             >
             where
                 Self: Sized,
             {
-                self.#child_ident.iter()
+                (&self.#child_ident).into_iter()
             }
 
             fn build(
                 &self,
-                _id: &::fynix::element::ElementId,
-                constraint: ::fynix::rectree::Constraint,
-                nodes: &mut ::fynix::element::ElementNodes,
-            ) -> ::fynix::rectree::Size {
-                use ::fynix::rectree::NodeContext as _;
-                self.#child_ident
-                    .as_ref()
+                _id: &(#fynix::element::ElementId),
+                constraint: #fynix::rectree::Constraint,
+                nodes: &mut #fynix::element::ElementNodes,
+            ) -> #fynix::rectree::Size {
+                use #fynix::rectree::NodeContext as _;
+                (&self.#child_ident)
+                    .into_iter()
                     .map(|c| nodes.get_size(c))
-                    .unwrap_or(::fynix::rectree::Size::ZERO)
+                    .next()
+                    .unwrap_or(#fynix::rectree::Size::ZERO)
             }
         }
     }

--- a/crates/fynix_macros/src/lib.rs
+++ b/crates/fynix_macros/src/lib.rs
@@ -107,7 +107,8 @@ fn parse_element_attrs(
     })
 }
 
-/// Derives `ElementNew`, `ElementChildren`, and `ElementSlot` for the annotated struct.
+/// Derives `ElementNew`, `ElementChildren`, `ElementSlot`, and `Element` for the annotated struct.
+/// Implement `ElementBuild` manually.
 #[proc_macro_derive(Element, attributes(children, element))]
 pub fn derive_element(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -210,10 +211,15 @@ pub fn derive_element(input: TokenStream) -> TokenStream {
         }
     };
 
+    let element_impl = quote! {
+        impl #fynix::element::Element for #name {}
+    };
+
     quote! {
         #slot_tokens
         #new_impl
         #children_impl
+        #element_impl
     }
     .into()
 }

--- a/crates/fynix_macros/src/lib.rs
+++ b/crates/fynix_macros/src/lib.rs
@@ -1,22 +1,13 @@
 use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
+use syn::Data;
 use syn::DeriveInput;
+use syn::Fields;
+use syn::Ident;
 use syn::parse_macro_input;
 
-/// Derives `typeslot::TypeSlot<fynix::element::ElementGroup>`
-/// for the annotated type.
-///
-/// Equivalent to writing:
-///
-/// ```ignore
-/// #[derive(::typeslot::TypeSlot)]
-/// #[slot(::fynix::element::ElementGroup)]
-/// ```
-#[proc_macro_derive(ElementSlot)]
-pub fn derive_element_slot(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
-    let name = &input.ident;
-
+fn element_slot_tokens(name: &Ident) -> TokenStream2 {
     quote! {
         const _: () = {
             static __SLOT: ::typeslot::AtomicSlot =
@@ -48,6 +39,140 @@ pub fn derive_element_slot(input: TokenStream) -> TokenStream {
                 }
             }
         };
+    }
+}
+
+/// Derives `typeslot::TypeSlot<fynix::element::ElementGroup>`
+/// for the annotated type.
+///
+/// Equivalent to writing:
+///
+/// ```ignore
+/// #[derive(::typeslot::TypeSlot)]
+/// #[slot(::fynix::element::ElementGroup)]
+/// ```
+#[proc_macro_derive(ElementSlot)]
+pub fn derive_element_slot(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    element_slot_tokens(&input.ident).into()
+}
+
+/// Derives a default `fynix::element::Element` implementation
+/// for a single-child element.
+///
+/// Also derives `ElementSlot` - no need to add it separately.
+///
+/// The struct must have exactly one field marked `#[child]`,
+/// typed as `Option<ElementId>`. The generated impl:
+///
+/// - `new` - constructs via `Default::default`.
+/// - `children` - yields the `#[child]` field.
+/// - `build` - returns the child's computed size, or
+///   `Size::ZERO` when no child is set.
+///
+/// ```ignore
+/// #[derive(Element, Default)]
+/// pub struct MyElement {
+///     #[child]
+///     child: Option<ElementId>,
+/// }
+/// ```
+#[proc_macro_derive(Element, attributes(child))]
+pub fn derive_element(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+
+    let fields = match &input.data {
+        Data::Struct(s) => &s.fields,
+        _ => {
+            return syn::Error::new_spanned(
+                name,
+                "#[derive(Element)] only supports structs",
+            )
+            .to_compile_error()
+            .into();
+        }
+    };
+
+    let named = match fields {
+        Fields::Named(f) => &f.named,
+        _ => {
+            return syn::Error::new_spanned(
+                name,
+                "#[derive(Element)] requires named fields",
+            )
+            .to_compile_error()
+            .into();
+        }
+    };
+
+    let child_fields: Vec<_> = named
+        .iter()
+        .filter(|f| {
+            f.attrs.iter().any(|a| a.path().is_ident("child"))
+        })
+        .collect();
+
+    let child_field = match child_fields.len() {
+        1 => child_fields[0],
+        0 => {
+            return syn::Error::new_spanned(
+                name,
+                "#[derive(Element)] requires exactly one \
+                 #[child] field",
+            )
+            .to_compile_error()
+            .into();
+        }
+        _ => {
+            return syn::Error::new_spanned(
+                child_fields[1],
+                "#[derive(Element)] found multiple #[child] \
+                 fields; only one is allowed",
+            )
+            .to_compile_error()
+            .into();
+        }
+    };
+
+    let child_ident = child_field.ident.as_ref().unwrap();
+    let slot_tokens = element_slot_tokens(name);
+
+    quote! {
+        #slot_tokens
+
+        impl ::fynix::element::Element for #name {
+            fn new() -> Self
+            where
+                Self: Sized,
+            {
+                ::core::default::Default::default()
+            }
+
+            fn children(
+                &self,
+            ) -> impl ::core::iter::IntoIterator<
+                Item = &::fynix::element::ElementId,
+            >
+            where
+                Self: Sized,
+            {
+                self.#child_ident.iter()
+            }
+
+            fn build(
+                &self,
+                _id: &::fynix::element::ElementId,
+                constraint: ::fynix::rectree::Constraint,
+                nodes: &mut ::fynix::element::ElementNodes,
+            ) -> ::fynix::rectree::Size {
+                use ::fynix::rectree::NodeContext as _;
+                self.#child_ident
+                    .as_ref()
+                    .map(|c| nodes.get_size(c))
+                    .unwrap_or(::fynix::rectree::Size::ZERO)
+            }
+        }
     }
     .into()
 }

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -29,22 +29,21 @@ consumed to build the subtree.
 ### Usage
 
 ```rust
-struct Hierarchy {
-    filter: String,
-    child: ElementId,
+struct Hierarchy<'a> {
+    filter: &'a str,
 }
 
 // In fynix_bevy (or any backend crate):
-impl Composer<BevyWorld> for Hierarchy {
+impl Composer<BevyWorld> for Hierarchy<'_> {
     fn compose(self, ctx: &mut FynixCtx<BevyWorld>) -> ElementId {
-        let items = ctx.world.query_filtered(&self.filter);
+        let items = ctx.world.query_filtered(self.filter);
         // ...
         ctx.add::<Label>()
     }
 }
 
 // In fynix_custom:
-impl Composer<CustomWorld> for Hierarchy {
+impl Composer<CustomWorld> for Hierarchy<'_> {
     fn compose(self, ctx: &mut FynixCtx<CustomWorld>) -> ElementId {
         ctx.add::<Label>()
     }
@@ -53,10 +52,7 @@ impl Composer<CustomWorld> for Hierarchy {
 
 ```rust
 fn create_ui(ctx: &mut FynixCtx<BevyWorld>) {
-    ctx.compose(Hierarchy {
-        filter: "enemy".into(),
-        child: ctx.add::<Label>(),
-    });
+    ctx.compose(Hierarchy { filter: "enemy" });
 }
 ```
 

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -3,7 +3,7 @@
 | Area                                 | Status                            |
 |--------------------------------------|-----------------------------------|
 | Unit system (`src/unit.rs`)          | Planned, not started              |
-| Element composers                    | Planned, not started              |
+| Element composers                    | Ready to start                    |
 | Interactions & Events                | Planned, not started              |
 | Reactivity (`Signals`)               | Deferred until after first render |
 | `TypeSlot` / typed table opt.        | In progress...                    |
@@ -12,98 +12,59 @@
 
 ## Element composers
 
-Element compose behavior is registered externally via
-`ElementComposers`, keeping element structs as pure data and
-backends decoupled from `fynix_elements`.
-
-### Types
+`Composer<W>` is a trait separate from `Element`. Element structs
+remain pure data; composition logic - how children are built for a
+given world - lives in the `Composer<W>` impl. This keeps
+`fynix_elements` decoupled from any backend.
 
 ```rust
-// Typed composer function for element E in world W.
-pub type ElementComposerFn<E, W> = fn(&mut E, &mut FynixCtx<W>);
-
-// Typed wrapper - monomorphized for (E, W).
-pub struct ElementComposer<E: Element, W> { ... }
-
-// Fully type-erased - stores TypeId for both E and W
-// alongside a *const () function pointer.
-// unsafe impl Sync - the pointer is always a fn pointer.
-pub struct UntypedElementComposer {
-    element_id: TypeId,
-    world_id: TypeId,
-    compose_fn: *const (),
-}
-
-// Non-generic registry keyed on element TypeId.
-pub struct ElementComposers {
-    composers: HashMap<TypeId, UntypedElementComposer>,
+pub trait Composer<W> {
+    fn compose(self, ctx: &mut FynixCtx<W>) -> ElementId;
 }
 ```
 
-`UntypedElementComposer::new::<E, W>(f)` is `const` - both
-`TypeId::of` calls are const-stable when `T: 'static`.
+`compose` takes ownership of `self`: the struct is the input data,
+consumed to build the subtree.
 
-### Auto-registration via `linkme`
-
-A `linkme` distributed slice collects composers across crates:
+### Usage
 
 ```rust
-#[distributed_slice]
-pub static ELEMENT_COMPOSERS: [UntypedElementComposer] = [..];
-```
-
-At startup, `ElementComposers` is populated from the slice in
-one pass.
-
-### `#[fynix(compose)]` proc-macro
-
-A proc-macro attribute handles registration boilerplate. `E`
-is inferred from the first parameter (`&mut E`), `W` from
-`FynixCtx<W>` in the second:
-
-```rust
-#[fynix(compose)]
-fn compose_hierarchy_bevy(
-    e: &mut Hierarchy,
-    ctx: &mut FynixCtx<BevyWorld>,
-) {
-    let h = ctx.world.query(..);
-    ctx.add::<Label>();
-    // ...
+struct Hierarchy {
+    filter: String,
+    child: ElementId,
 }
 
-#[fynix(compose)]
-fn compose_hierarchy_custom(
-    e: &mut Hierarchy,
-    ctx: &mut FynixCtx<CustomWorld>,
-) {
-    ctx.add::<Label>();
-    ctx.add::<Button>();
-    // ...
+// In fynix_bevy (or any backend crate):
+impl Composer<BevyWorld> for Hierarchy {
+    fn compose(self, ctx: &mut FynixCtx<BevyWorld>) -> ElementId {
+        let items = ctx.world.query_filtered(&self.filter);
+        // ...
+        ctx.add::<Label>()
+    }
+}
+
+// In fynix_custom:
+impl Composer<CustomWorld> for Hierarchy {
+    fn compose(self, ctx: &mut FynixCtx<CustomWorld>) -> ElementId {
+        ctx.add::<Label>()
+    }
 }
 ```
 
-Expands to the function plus:
-
 ```rust
-#[linkme::distributed_slice(fynix::ELEMENT_COMPOSERS)]
-static _ELEMENT_COMPOSER_COMPOSE_HIERARCHY_BEVY:
-    UntypedElementComposer =
-    UntypedElementComposer::new::<Hierarchy, BevyWorld>(
-        compose_hierarchy_bevy,
-    );
-```
-
-Usage:
-
-```rust
-fn create_ui(ctx: FynixCtx<BevyWorld>) {
-    ctx.add::<Hierarchy>();
+fn create_ui(ctx: &mut FynixCtx<BevyWorld>) {
+    ctx.compose(Hierarchy {
+        filter: "enemy".into(),
+        child: ctx.add::<Label>(),
+    });
 }
 ```
 
-The static name is derived from the function name to
-guarantee uniqueness within a module.
+### Reactive re-composition
+
+When a signal that scopes a composer's subtree changes, the old
+children are removed and `compose` is re-called with fresh data.
+See the reactive scopes section under Signals.
 
 ---
 

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -3,80 +3,10 @@
 | Area                                 | Status                            |
 |--------------------------------------|-----------------------------------|
 | Unit system (`src/unit.rs`)          | Planned, not started              |
-| `#[derive(Element)]` macro           | Planned, not started              |
 | Element composers                    | Planned, not started              |
 | Interactions & Events                | Planned, not started              |
 | Reactivity (`Signals`)               | Deferred until after first render |
 | `TypeSlot` / typed table opt.        | In progress...                    |
-
----
-
-## `#[derive(Element)]` macro
-
-A derive macro that implements the `Element` trait automatically.
-Requires the struct to implement `Default`, which provides `new()`.
-
-```rust
-#[derive(Element, Default)]
-struct Horizontal {
-    #[children]
-    children: Vec<ElementId>,
-    gap: f32,
-}
-```
-
-### `#[children]` field attribute
-
-Fields marked `#[children]` are auto-registered as the element's
-child list. The macro implements `Element::children()` by calling
-`into_iter()` on the marked field by default.
-
-An optional method chain can be specified for types that need one
-to produce the iterator:
-
-```rust
-// Default - calls into_iter() on the field.
-#[children]
-children: Vec<ElementId>,
-
-// With method chain - calls .keys() first.
-#[children(.keys())]
-children: BTreeMap<ElementId, LayoutData>,
-```
-
-One element can have at most one `#[children]` field.
-
-### `#[child]` field attribute
-
-Fields marked `#[child]` hold a single `ElementId`. Use this for
-wrapper elements that contain exactly one child and need no custom
-layout logic. The macro implements both `Element::children()` and
-`Element::build()` automatically.
-
-```rust
-#[derive(Element, Default)]
-struct Button {
-    pub label: String,
-    #[child]
-    child: ElementId,
-}
-```
-
-Generated `build` delegates sizing to the child:
-
-```rust
-fn build(&self, id: &ElementId, constraint: Constraint, nodes: &mut ElementNodes) -> Size {
-    nodes.get_size(&self.child)
-        .map(|s| constraint.constrain(s))
-        .unwrap_or(constraint.min)
-}
-```
-
-Override `build` manually when the wrapper needs custom sizing on
-top of its child.
-
-One element can have at most one `#[child]` or `#[children]` field,
-not both.
 
 ---
 

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -12,47 +12,54 @@
 
 ## Element composers
 
-`Composer<W>` is a trait separate from `Element`. Element structs
-remain pure data; composition logic - how children are built for a
-given world - lives in the `Composer<W>` impl. This keeps
-`fynix_elements` decoupled from any backend.
+`Composer<W>` is a trait separate from `Element`. It separates
+required caller inputs from styleable element data:
+
+- The **element** (`Hierarchy`) is a normal `Element` - pure data,
+  styleable via `ctx.set`.
+- The **composer** (`HierarchyComposer`) holds required inputs and
+  builds the element. It is not an `Element` itself.
+
+`ctx.compose()` calls `compose`, applies the style chain to the
+returned element, and inserts it into the tree.
 
 ```rust
 pub trait Composer<W> {
-    fn compose(self, ctx: &mut FynixCtx<W>) -> ElementId;
+    type Element: Element;
+    fn compose(self, ctx: &mut FynixCtx<W>) -> Self::Element;
 }
 ```
-
-`compose` takes ownership of `self`: the struct is the input data,
-consumed to build the subtree.
 
 ### Usage
 
 ```rust
-struct Hierarchy<'a> {
+#[derive(Element, Default)]
+struct Hierarchy {
+    font_size: f32,
+    #[children]
+    children: Vec<ElementId>,
+}
+
+struct HierarchyComposer<'a> {
     filter: &'a str,
 }
 
-// In fynix_bevy (or any backend crate):
-impl Composer<BevyWorld> for Hierarchy<'_> {
-    fn compose(self, ctx: &mut FynixCtx<BevyWorld>) -> ElementId {
-        let items = ctx.world.query_filtered(self.filter);
-        // ...
-        ctx.add::<Label>()
-    }
-}
-
-// In fynix_custom:
-impl Composer<CustomWorld> for Hierarchy<'_> {
-    fn compose(self, ctx: &mut FynixCtx<CustomWorld>) -> ElementId {
-        ctx.add::<Label>()
+impl Composer<BevyWorld> for HierarchyComposer<'_> {
+    type Element = Hierarchy;
+    fn compose(self, ctx: &mut FynixCtx<BevyWorld>) -> Hierarchy {
+        let mut h = Hierarchy::default();
+        for _ in ctx.world.query_filtered(self.filter) {
+            h.children.push(ctx.add::<Label>());
+        }
+        h
     }
 }
 ```
 
 ```rust
 fn create_ui(ctx: &mut FynixCtx<BevyWorld>) {
-    ctx.compose(Hierarchy { filter: "enemy" });
+    ctx.set(field_accessor!(<Hierarchy>::font_size), 24.0);
+    ctx.compose(HierarchyComposer { filter: "enemy" });
 }
 ```
 


### PR DESCRIPTION
- Splits the `Element` trait into `ElementNew` (construction), `ElementChildren` (child iteration), and `ElementBuild` (layout/render)
- Adds `#[derive(Element)]` which generates the boilerplate for `ElementSlot`, `ElementNew`, and `ElementChildren`.
- Adds `#[derive(ElementSlot)]` for type registration only

## Example

```rust
#[derive(Element, Default, Clone)]
struct Vertical {
    #[children]
    children: Vec<ElementId>,
}

impl ElementBuild for Vertical {
    fn build(&self, ..) -> Size { .. }
}
```

- `#[children]` works on anything that implements `IntoIterator<&ElementId>`
- Struct-level overrides via `#[element(new = fn, children = fn)]` for custom construction or child iteration.