### PR TITLE
Fix nested primary child removal

### DIFF
--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -4,8 +4,6 @@ use crate::Fynix;
 use crate::element::{Element, ElementId};
 use crate::style::{StyleId, StyleValue};
 
-// TODO: Docs probably needs to be updated with the new `parent_element_id`.
-
 /// Build-time context for constructing the element tree and declaring
 /// style defaults.
 ///
@@ -17,7 +15,7 @@ use crate::style::{StyleId, StyleValue};
 ///
 /// Style changes queued with [`Self::set`] are committed into a new
 /// [`Style`] node the next time an element is added. Inside an
-/// [`Self::add_with`] closure, the outer `parent_style_id` is saved
+/// [`Self::add_with`] closure, the outer `prev_style` is saved
 /// and restored after the closure returns, so inner style changes do
 /// not leak outward.
 ///
@@ -26,7 +24,6 @@ pub struct FynixCtx<'f, 'w, W> {
     fynix: &'f mut Fynix,
     pub world: &'w mut W,
 
-    // TODO: We need a way to actually create & represent these.
     prev_style: Option<StyleId>,
     /// The first style created within the current context.
     primary_style: Option<StyleId>,
@@ -57,11 +54,11 @@ impl<W> FynixCtx<'_, '_, W> {
         self.fynix.elements.add(element, None)
     }
 
-    /// Like [`Self::add`], but also runs `f` for inline mutations and
+    /// Like [`Self::add`], but also runs `scope` for inline mutations and
     /// nested element additions.
     ///
-    /// The outer `parent_style_id` is restored after `f` returns, so
-    /// any [`Self::set`] calls inside `f` do not affect elements
+    /// The outer `prev_style` is restored after `scope` returns, so
+    /// any [`Self::set`] calls inside `scope` do not affect elements
     /// added after this call.
     ///
     /// The element's `primary_style` is set to the first style

--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -4,6 +4,8 @@ use crate::Fynix;
 use crate::element::{Element, ElementId};
 use crate::style::{StyleId, StyleValue};
 
+// TODO: Docs probably needs to be updated with the new `parent_element_id`.
+
 /// Build-time context for constructing the element tree and declaring
 /// style defaults.
 ///
@@ -21,21 +23,26 @@ use crate::style::{StyleId, StyleValue};
 ///
 /// [`Style`]: crate::style::Style
 pub struct FynixCtx<'f, 'w, W> {
-    parent_style_id: Option<StyleId>,
     fynix: &'f mut Fynix,
     pub world: &'w mut W,
+
+    // TODO: We need a way to actually create & represent these.
+    prev_style: Option<StyleId>,
+    /// The first style created within the current context.
+    primary_style: Option<StyleId>,
 }
 
 impl<W> FynixCtx<'_, '_, W> {
     pub(crate) fn new<'f, 'w>(
-        parent_style_id: Option<StyleId>,
         fynix: &'f mut Fynix,
         world: &'w mut W,
+        prev_style: Option<StyleId>,
     ) -> FynixCtx<'f, 'w, W> {
         FynixCtx {
-            parent_style_id,
             fynix,
             world,
+            prev_style,
+            primary_style: None,
         }
     }
 
@@ -46,8 +53,8 @@ impl<W> FynixCtx<'_, '_, W> {
     /// `primary_style` is `None`
     #[must_use]
     pub fn add<E: Element>(&mut self) -> ElementId {
-        let element = self.create_element::<E>(false);
-        self.fynix.elements.add(element)
+        let element = self.create_element::<E>();
+        self.fynix.elements.add(element, None)
     }
 
     /// Like [`Self::add`], but also runs `f` for inline mutations and
@@ -65,49 +72,33 @@ impl<W> FynixCtx<'_, '_, W> {
     #[must_use]
     pub fn add_with<E: Element>(
         &mut self,
-        f: impl FnOnce(&mut E, &mut Self),
+        scope: impl FnOnce(&mut E, &mut Self),
     ) -> ElementId {
-        let pre_commit_id = self.parent_style_id;
+        let mut element = self.create_element::<E>();
 
-        let mut element = self.create_element::<E>(true);
+        let prev_style_id = self.prev_style;
+        let primary_style = self.primary_style.take();
 
-        let pre_fn_id = self.parent_style_id;
+        scope(&mut element, self);
 
-        // styleId from create_element
-        // else, current uncomited style if is None
-        let first_inner_style_id = self
-            .parent_style_id
-            .filter(|id| Some(*id) != pre_commit_id)
-            .unwrap_or_else(|| self.fynix.styles.current_id());
+        let id = self
+            .fynix
+            .elements
+            .add(element, self.primary_style.take());
 
-        f(&mut element, self);
+        // Restore pre-closure state.
+        self.prev_style = prev_style_id;
+        self.primary_style = primary_style;
 
-        // If self.parent_style_id has changed, that means a
-        // style has been committed inside the closure.
-        // It's ID would be that of `first_inner_style_id`,
-        // so our primary style is set to that.
-        let primary_style = if self.parent_style_id != pre_commit_id {
-            Some(first_inner_style_id)
-        } else {
-            None
-        };
-
-        // restore to old value
-        self.parent_style_id = pre_fn_id;
-
-        let id = self.fynix.elements.add(element);
-
-        if let Some(style_id) = primary_style
-            && let Some(meta) = self.fynix.elements.metas.get_mut(&id)
-        {
-            meta.primary_style = Some(style_id);
-        }
+        // Clears all style leftovers to prevent them from leaking
+        // outside the scope.
+        self.fynix.styles.clear_builder();
 
         id
     }
 
-    /// Queues a style default: field `field_accessor` on element type `E`
-    /// will be set to `value` for all elements added after this call (within
+    /// Queues a style default: field `T` on element type `E` will be
+    /// set to `value` for all elements added after this call (within
     /// the current scope).
     pub fn set<E: Element, T: StyleValue>(
         &mut self,
@@ -119,31 +110,33 @@ impl<W> FynixCtx<'_, '_, W> {
 
     /// Commits any pending style changes, constructs `E::new()`, and
     /// applies the current style chain to it.
-    ///
-    /// `is_deeper` indicates whether the committed style should go
-    /// into children\[0\] (deeper scope) or children\[1\]
-    /// (sibling node at same scope).
-    fn create_element<E: Element>(&mut self, is_deeper: bool) -> E {
+    fn create_element<E: Element>(&mut self) -> E {
         if self.fynix.styles.should_commit() {
             let committed_id = self.fynix.styles.current_id();
 
+            let is_nested = self.primary_style.is_none();
+
             self.fynix
                 .styles
-                .commit_styles(self.parent_style_id, is_deeper);
-            self.parent_style_id = Some(committed_id);
+                .commit_styles(self.prev_style, is_nested);
+            self.prev_style = Some(committed_id);
+
+            if is_nested {
+                self.primary_style = Some(committed_id);
+            }
         }
 
         let mut element = E::new();
-        if let Some(id) = &self.parent_style_id {
+        if let Some(id) = &self.prev_style {
             self.fynix.styles.apply(&mut element, id);
         }
+
         element
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use alloc::string::{String, ToString};
     use alloc::vec::Vec;
 
     use field_path::field_accessor;
@@ -151,13 +144,12 @@ mod tests {
 
     use crate::element::ElementBuild;
     use crate::element::layout::ElementNodes;
-    use crate::init;
 
     use super::*;
 
     #[derive(Element, Default, Clone)]
     struct Label {
-        pub text: String,
+        pub text: &'static str,
     }
 
     impl ElementBuild for Label {
@@ -209,15 +201,11 @@ mod tests {
 
     #[test]
     fn style_applied_after_set() {
-        crate::init();
         let mut world = ();
         let mut fynix = Fynix::new();
         let root_id = {
             let mut ctx = fynix.root_ctx(&mut world);
-            ctx.set(
-                field_accessor!(<Label>::text),
-                "hello".to_string(),
-            );
+            ctx.set(field_accessor!(<Label>::text), "hello");
             ctx.add_with::<Vertical>(|v, ctx| {
                 v.add(ctx.add::<Label>());
             })
@@ -233,22 +221,15 @@ mod tests {
 
     #[test]
     fn add_with_restores_parent_style_id() {
-        crate::init();
         let mut world = ();
         let mut fynix = Fynix::new();
         let root_id = {
             let mut ctx = fynix.root_ctx(&mut world);
-            ctx.set(
-                field_accessor!(<Label>::text),
-                "outer".to_string(),
-            );
+            ctx.set(field_accessor!(<Label>::text), "outer");
             ctx.add_with::<Vertical>(|v, ctx| {
                 // Inner scope overrides the label text.
                 let inner_id = ctx.add_with::<Vertical>(|v, ctx| {
-                    ctx.set(
-                        field_accessor!(<Label>::text),
-                        "inner".to_string(),
-                    );
+                    ctx.set(field_accessor!(<Label>::text), "inner");
                     v.add(ctx.add::<Label>());
                 });
 
@@ -271,20 +252,13 @@ mod tests {
 
     #[test]
     fn child_style_wins_over_parent() {
-        crate::init();
         let mut world = ();
         let mut fynix = Fynix::new();
         let root_id = {
             let mut ctx = fynix.root_ctx(&mut world);
-            ctx.set(
-                field_accessor!(<Label>::text),
-                "parent".to_string(),
-            );
+            ctx.set(field_accessor!(<Label>::text), "parent");
             ctx.add_with::<Vertical>(|v, ctx| {
-                ctx.set(
-                    field_accessor!(<Label>::text),
-                    "child".to_string(),
-                );
+                ctx.set(field_accessor!(<Label>::text), "child");
                 v.add(ctx.add::<Label>());
             })
         };
@@ -298,98 +272,145 @@ mod tests {
     }
 
     #[test]
-    fn style_tree_cleanup_on_element_removal() {
-        init();
-
+    fn style_tree_cleanup() {
         let mut world = ();
         let mut fynix = Fynix::new();
-        let element_a = {
-            let mut ctx = fynix.root_ctx(&mut world);
-            ctx.set(field_accessor!(<Label>::text), "a".to_string());
-            ctx.add_with::<Vertical>(|v, ctx| {
-                ctx.set(
-                    field_accessor!(<Label>::text),
-                    "b".to_string(),
-                );
-                v.add(ctx.add::<Label>());
-                ctx.set(
-                    field_accessor!(<Label>::text),
-                    "c".to_string(),
-                );
-                v.add(ctx.add::<Label>());
-            })
+        let mut ctx = fynix.root_ctx(&mut world);
+
+        ctx.set(field_accessor!(<Label>::text), "z");
+        let elem_a = ctx.add::<Label>();
+
+        let mut elem_c = ElementId::PLACEHOLDER;
+        let mut elem_d = ElementId::PLACEHOLDER;
+        let mut elem_e = ElementId::PLACEHOLDER;
+        let mut elem_f = ElementId::PLACEHOLDER;
+        let elem_b = ctx.add_with::<Vertical>(|v, ctx| {
+            ctx.set(field_accessor!(<Label>::text), "a");
+
+            v.add({
+                elem_c = ctx.add_with::<Vertical>(|v, ctx| {
+                    ctx.set(field_accessor!(<Label>::text), "b");
+
+                    v.add({
+                        elem_d =
+                            ctx.add_with::<Vertical>(|v, ctx| {
+                                // Trigger `create_element` without
+                                // any prior style.
+                                v.add(ctx.add::<Label>());
+
+                                ctx.set(
+                                    field_accessor!(<Label>::text),
+                                    "c",
+                                );
+                                v.add({
+                                    elem_e = ctx
+                                        .add_with::<Label>(|_, _| {});
+                                    elem_e
+                                });
+
+                                ctx.set(
+                                    field_accessor!(<Label>::text),
+                                    "d",
+                                );
+                                v.add({
+                                    elem_f = ctx.add::<Label>();
+                                    elem_f
+                                });
+                            });
+                        elem_d
+                    });
+                });
+                elem_c
+            });
+        });
+
+        let mut len = fynix.styles.styles.len();
+        // Verify we have 6 styles [z, a, b, c, d].
+        assert_eq!(len, 5);
+
+        let has_primary_style = |e: &ElementId| {
+            fynix
+                .elements
+                .metas
+                .get(e)
+                .and_then(|m| m.primary_style)
+                .is_some()
         };
 
-        // Verify we have 3 styles (a, b, c).
-        assert_eq!(
-            fynix.styles.styles.len(),
-            3,
-            "Should have 3 styles before removal"
-        );
-
-        // Get the primary style for element_a.
-        let primary_style = fynix
-            .elements
-            .metas
-            .get(&element_a)
-            .and_then(|m| m.primary_style);
         assert!(
-            primary_style.is_some(),
-            "Element should have primary style"
+            ![elem_a, elem_e, elem_f].iter().any(has_primary_style)
+        );
+        assert!(
+            [elem_b, elem_c, elem_d].iter().all(has_primary_style)
         );
 
-        // Remove element_a, which should also remove its style tree.
-        fynix.remove_element(&element_a);
+        // No styles removed.
+        fynix.remove_element(&elem_a);
+        assert_eq!(fynix.styles.styles.len(), len);
 
-        // After removal, all 3 styles (a, b, c) should be gone.
-        assert_eq!(
-            fynix.styles.styles.len(),
-            0,
-            "All styles should be removed with primary style"
-        );
+        // No styles removed.
+        fynix.remove_element(&elem_f);
+        assert_eq!(fynix.styles.styles.len(), len);
+
+        // No styles removed.
+        fynix.remove_element(&elem_e);
+        assert_eq!(fynix.styles.styles.len(), len);
+
+        // [c, d] will be removed.
+        fynix.remove_element(&elem_d);
+        len -= 2;
+        assert_eq!(fynix.styles.styles.len(), len);
+
+        // [b] will be removed.
+        fynix.remove_element(&elem_c);
+        len -= 1;
+        assert_eq!(fynix.styles.styles.len(), len);
+
+        // [a] will be removed.
+        fynix.remove_element(&elem_b);
+        len -= 1;
+        assert_eq!(fynix.styles.styles.len(), len);
+
+        // Only [z] remains.
+        assert_eq!(len, 1);
     }
 
     #[test]
-    fn element_without_primary_style_no_cleanup() {
-        init();
-
+    fn nested_style_tree_cleanup() {
         let mut world = ();
         let mut fynix = Fynix::new();
-        let (element_a, element_b) = {
-            let mut ctx = fynix.root_ctx(&mut world);
-            ctx.set(field_accessor!(<Label>::text), "a".to_string());
-            let a = ctx.add_with::<Vertical>(|v, ctx| {
-                ctx.set(
-                    field_accessor!(<Label>::text),
-                    "b".to_string(),
-                );
-                v.add(ctx.add::<Label>());
-            });
-            ctx.set(field_accessor!(<Label>::text), "c".to_string());
-            let b = ctx.add::<Label>();
-            (a, b)
+        let mut ctx = fynix.root_ctx(&mut world);
+
+        let mut elem_b = ElementId::PLACEHOLDER;
+        let elem_a = ctx.add_with::<Vertical>(|v, ctx| {
+            v.add(ctx.add_with::<Vertical>(|v, ctx| {
+                v.add({
+                    elem_b = ctx.add_with::<Vertical>(|v, ctx| {
+                        ctx.set(field_accessor!(<Label>::text), "a");
+                        v.add(ctx.add::<Label>());
+                    });
+                    elem_b
+                })
+            }));
+        });
+
+        // Verify we have 1 style [a].
+        assert_eq!(fynix.styles.styles.len(), 1);
+
+        let has_primary_style = |e: &ElementId| {
+            fynix
+                .elements
+                .metas
+                .get(e)
+                .and_then(|m| m.primary_style)
+                .is_some()
         };
 
-        // Should have 3 styles (a, b, c).
-        assert_eq!(fynix.styles.styles.len(), 3);
+        assert!(!has_primary_style(&elem_a));
+        assert!(has_primary_style(&elem_b));
 
-        // element_b has no primary_style (created with add(), not add_with()).
-        let b_primary = fynix
-            .elements
-            .metas
-            .get(&element_b)
-            .and_then(|m| m.primary_style);
-        assert!(b_primary.is_none());
-
-        // Remove element_b - should not affect styles.
-        fynix.remove_element(&element_b);
-
-        // All 3 styles should still exist.
-        assert_eq!(fynix.styles.styles.len(), 3);
-
-        // Remove element_a - should remove its style tree (a, b).
-        fynix.remove_element(&element_a);
-        // Style c should remain (not part of element_a's tree).
-        assert_eq!(fynix.styles.styles.len(), 1);
+        // [a] will be removed.
+        fynix.remove_element(&elem_a);
+        assert_eq!(fynix.styles.styles.len(), 0);
     }
 }

--- a/crates/fynix/src/element.rs
+++ b/crates/fynix/src/element.rs
@@ -7,6 +7,7 @@ use crate::element::meta::{ElementMetas, ElementTypeMetas};
 use crate::element::table::ElementTable;
 use crate::id::{GenId, IdGenerator};
 use crate::resource::Resources;
+use crate::style::{StyleId, Styles};
 
 pub use fynix_macros::{Element, ElementSlot, ElementTemplate};
 
@@ -130,12 +131,16 @@ impl Elements {
 
     /// Stores `element`, registers its type getter if needed,
     /// and returns a fresh [`ElementId`].
-    pub fn add<E: Element>(&mut self, element: E) -> ElementId {
+    pub fn add<E: Element>(
+        &mut self,
+        element: E,
+        primary_style: Option<StyleId>,
+    ) -> ElementId {
         self.type_metas.register::<E>();
 
         let id = self.id_generator.new_id();
 
-        self.metas.init_element::<E>(id);
+        self.metas.init_element::<E>(id, primary_style);
         self.elements.insert(id, element);
         id
     }
@@ -172,21 +177,34 @@ impl Elements {
         self.elements.get_mut::<E>(id)
     }
 
-    /// Recursively removes the element subtree.
+    /// Recursively removes the element subtree along with their styles.
     ///
     /// Returns `true` if the element was present and removed.
-    pub fn remove(&mut self, id: &ElementId) -> bool {
+    pub fn remove(
+        &mut self,
+        id: &ElementId,
+        styles: &mut Styles,
+    ) -> bool {
         fn remove_recursive(
             id: &ElementId,
             metas: &mut ElementMetas,
             type_metas: &ElementTypeMetas,
             elements: &mut ElementTable,
             id_generator: &mut ElementIdGenerator,
+            styles: &mut Styles,
+            mut has_removed_styles: bool,
         ) -> bool {
             if let Some(meta) = metas.remove(id)
                 && let Some(type_meta) =
                     type_metas.get_slot(meta.slot)
             {
+                if !has_removed_styles
+                    && let Some(primary_style) = meta.primary_style
+                {
+                    has_removed_styles =
+                        styles.remove(&primary_style);
+                }
+
                 (type_meta.for_each_child_mut_fn)(
                     elements,
                     id,
@@ -197,6 +215,8 @@ impl Elements {
                             type_metas,
                             elements,
                             id_generator,
+                            styles,
+                            has_removed_styles,
                         );
                     },
                 );
@@ -215,6 +235,8 @@ impl Elements {
             &self.type_metas,
             &mut self.elements,
             &mut self.id_generator,
+            styles,
+            false,
         )
     }
 

--- a/crates/fynix/src/element/meta.rs
+++ b/crates/fynix/src/element/meta.rs
@@ -15,7 +15,7 @@ pub struct ElementMeta {
     pub node: RectNode<ElementId>,
     pub cached_scene: Option<Scene>,
     /// When this element is removed, this style and all its
-    /// descendants in the style tree are also removed
+    /// descendants in the style tree are also removed.
     pub primary_style: Option<StyleId>,
 }
 
@@ -31,14 +31,18 @@ impl ElementMetas {
         }
     }
 
-    pub fn init_element<E: Element>(&mut self, id: ElementId) {
+    pub fn init_element<E: Element>(
+        &mut self,
+        id: ElementId,
+        primary_style: Option<StyleId>,
+    ) {
         self.map.insert(
             id,
             ElementMeta {
                 slot: ElementGroup::slot::<E>(),
                 node: RectNode::new(None),
                 cached_scene: None,
-                primary_style: None,
+                primary_style,
             },
         );
     }

--- a/crates/fynix/src/element/table.rs
+++ b/crates/fynix/src/element/table.rs
@@ -9,9 +9,9 @@ use typeslot::SlotGroup;
 
 /// Slot-indexed element storage, keyed by [`ElementId`].
 ///
-/// Each element type is assigned a unique slot index at
-/// startup by [`crate::init`]. Typed access is then a direct
-/// [`Vec`] index.
+/// Each element type is assigned a unique slot index at startup by
+/// [`crate::Fynix::new`].
+/// Typed access is then a direct [`Vec`] index.
 pub struct ElementTable {
     columns: Vec<Option<DynTypeMap<ElementId>>>,
 }

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -31,7 +31,7 @@ mod id;
 /// Must be called before any element is added to a [`Fynix`]
 /// instance. Safe to call more than once - subsequent calls
 /// are no-ops.
-pub fn init() {
+fn init() {
     static INITIALIZED: AtomicBool = AtomicBool::new(false);
     if INITIALIZED
         .compare_exchange(
@@ -60,6 +60,7 @@ pub struct Fynix {
 
 impl Fynix {
     pub fn new() -> Self {
+        init();
         Self {
             elements: Elements::new(),
             styles: Styles::new(),
@@ -89,18 +90,10 @@ impl Fynix {
     /// Returns `true` if the element existed
     #[inline]
     pub fn remove_element(&mut self, id: &ElementId) -> bool {
-        let primary_style =
-            self.elements.metas.get(id).and_then(|m| m.primary_style);
-
-        if !self.elements.remove(id) {
+        // Removes the element subtree along with their styles.
+        if !self.elements.remove(id, &mut self.styles) {
             return false;
         }
-
-        // remove the style
-        if let Some(style_id) = primary_style {
-            self.styles.delete_tree(&style_id);
-        }
-
         true
     }
 
@@ -122,9 +115,9 @@ impl Fynix {
     pub fn create_ctx<'f, 'w, W>(
         &'f mut self,
         world: &'w mut W,
-        parent_style_id: Option<StyleId>,
+        parent_style: Option<StyleId>,
     ) -> FynixCtx<'f, 'w, W> {
-        FynixCtx::new(parent_style_id, self, world)
+        FynixCtx::new(self, world, parent_style)
     }
 }
 

--- a/crates/fynix/src/style.rs
+++ b/crates/fynix/src/style.rs
@@ -99,10 +99,9 @@ impl Styles {
 
     /// Adds `child_id` to the children of `parent_id`.
     ///
-    /// `is_deeper` refers to the child's scope relative to parent.
-    ///
-    /// If `is_deeper` is true, child is one scope deeper
-    /// Else, child is a sibling node (same depth in tree)
+    /// If `is_nested` is true, child is set as the `nested_child`
+    /// (one scope deeper). Otherwise, it is set as the `adjacent_child`
+    /// (same scope, next sibling node).
     fn add_child_to_style(
         &mut self,
         parent_id: StyleId,
@@ -220,12 +219,12 @@ impl Default for Styles {
 /// An immutable, committed snapshot of field changes for one
 /// style scope.
 ///
-/// Nodes form a singly-linked chain via `parent_id`.
-/// [`Styles::apply`] walks this chain to resolve inherited
-/// defaults.
+/// Each node links to its parent via `parent_id`, forming an inheritance
+/// chain that [`Styles::apply`] walks to resolve defaults.
 ///
-/// When a style is removed, all its descendants (children)
-/// are also removed.
+/// A node can have up to two children: `adjacent_child` (same scope,
+/// next sibling) and `nested_child` (one scope deeper). When a style
+/// is removed, all its descendants are also removed.
 pub struct Style {
     parent_id: Option<StyleId>,
     index_map: HashMap<TypeId, Span>,

--- a/crates/fynix/src/style.rs
+++ b/crates/fynix/src/style.rs
@@ -78,7 +78,7 @@ impl Styles {
     pub fn commit_styles(
         &mut self,
         parent_id: Option<StyleId>,
-        is_deeper: bool,
+        is_nested: bool,
     ) {
         let committed_id = self.current_id;
         let style =
@@ -87,7 +87,7 @@ impl Styles {
         self.styles.insert(committed_id, style);
 
         if let Some(parent) = parent_id {
-            self.add_child_to_style(parent, committed_id, is_deeper);
+            self.add_child_to_style(parent, committed_id, is_nested);
         }
 
         self.current_id = self.id_generator.new_id();
@@ -103,20 +103,18 @@ impl Styles {
         &mut self,
         parent_id: StyleId,
         child_id: StyleId,
-        is_deeper: bool,
+        is_nested: bool,
     ) {
         let Some(parent) = self.styles.get_mut(&parent_id) else {
             return;
         };
 
-        debug_assert!(parent.children.iter().any(|c| c.is_none()));
-
-        // [0] -> deeper depth
-        // [1] -> sibling style
-        if is_deeper {
-            parent.children[0] = Some(child_id);
+        if is_nested {
+            debug_assert!(parent.nested_child.is_none());
+            parent.nested_child = Some(child_id);
         } else {
-            parent.children[1] = Some(child_id);
+            debug_assert!(parent.adjacent_child.is_none());
+            parent.adjacent_child = Some(child_id);
         }
     }
 
@@ -148,34 +146,18 @@ impl Styles {
         self.style_builder.insert(type_id, untyped_field);
     }
 
-    /// Removes a committed style node and recycles its [`StyleId`].
-    ///
-    /// Returns `true` if the node was present and removed.
-    pub fn delete(&mut self, id: &StyleId) -> bool {
-        if self.style_values.remove_all(id) {
-            self.styles.remove(id);
-            self.id_generator.recycle(*id);
-            return true;
-        }
-
-        false
-    }
-
-    /// Recursively deletes a style and its children
-    pub fn delete_tree(&mut self, id: &StyleId) {
-        let Some(style) = self.styles.get(id) else {
-            return;
+    /// Recursively removes the style and their descendants.
+    pub fn remove(&mut self, id: &StyleId) -> bool {
+        let Some(style) = self.styles.remove(id) else {
+            return false;
         };
+        self.id_generator.recycle(*id);
 
-        let children = style.children;
-        self.delete(id);
-
-        for c in children {
-            let Some(c) = c else {
-                continue;
-            };
-            self.delete_tree(&c);
+        for c in style.children().into_iter().flatten() {
+            self.remove(c);
         }
+
+        true
     }
 
     /// Applies the style chain rooted at `id` to `element`.
@@ -244,10 +226,8 @@ pub struct Style {
     parent_id: Option<StyleId>,
     index_map: HashMap<TypeId, Span>,
     fields: Box<[UntypedField]>,
-    /// Treat the style's children as a (sort-of) binary tree.
-    /// `children[0]` is one depth deeper (inner scope).
-    /// `children[1]` is same depth, subsequent style node.
-    children: [Option<StyleId>; 2],
+    adjacent_child: Option<StyleId>,
+    nested_child: Option<StyleId>,
 }
 
 impl Style {
@@ -255,8 +235,16 @@ impl Style {
         self.parent_id
     }
 
-    pub fn children(&self) -> [Option<StyleId>; 2] {
-        self.children
+    pub fn children(&self) -> [Option<&StyleId>; 2] {
+        [self.adjacent_child.as_ref(), self.nested_child.as_ref()]
+    }
+
+    pub fn adjacent_child(&self) -> Option<&StyleId> {
+        self.adjacent_child.as_ref()
+    }
+
+    pub fn nested_child(&self) -> Option<&StyleId> {
+        self.nested_child.as_ref()
     }
 
     fn get_fields(&self, id: &TypeId) -> Option<&[UntypedField]> {
@@ -280,6 +268,10 @@ impl StyleBuilder {
 
     fn insert(&mut self, id: TypeId, field: UntypedField) {
         self.field_map.entry(id).or_default().insert(field);
+    }
+
+    fn clear(&mut self) {
+        self.field_map.clear();
     }
 
     fn is_empty(&self) -> bool {
@@ -307,7 +299,8 @@ impl StyleBuilder {
             parent_id,
             index_map,
             fields: all_fields.into_boxed_slice(),
-            children: [None; 2],
+            adjacent_child: None,
+            nested_child: None,
         }
     }
 }

--- a/crates/fynix/src/style.rs
+++ b/crates/fynix/src/style.rs
@@ -67,6 +67,10 @@ impl Styles {
         !self.style_builder.is_empty()
     }
 
+    pub fn clear_builder(&mut self) {
+        self.style_builder.clear();
+    }
+
     /// Flushes pending field changes into a new committed [`Style`] node
     /// and advances to a fresh [`StyleId`].
     ///

--- a/examples/vello_winit_examples/src/lib.rs
+++ b/examples/vello_winit_examples/src/lib.rs
@@ -54,8 +54,6 @@ pub enum RenderState<'s> {
 
 impl<D: FynixDemo> VelloWinitApp<'_, D> {
     pub fn new(mut demo: D) -> Self {
-        fynix::init();
-
         let mut fynix = Fynix::new();
         demo.init(&mut fynix);
 


### PR DESCRIPTION
Removing an element without a `primary_style` will leave a child element with `primary_style` untouched. This PR fixes that by moving the style deletion directly within `Element::remove`.