### PR TITLE
Add `Init` trait replacing `ElementNew`

### DIFF
--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -139,9 +139,9 @@ mod tests {
     use field_path::field_accessor;
     use rectree::{Constraint, NodeContext, Size, Vec2};
 
-    use crate::Init;
     use crate::element::ElementBuild;
     use crate::element::layout::ElementNodes;
+    use crate::init::Init;
 
     use super::*;
 

--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -105,7 +105,7 @@ impl<W> FynixCtx<'_, '_, W> {
         self.fynix.styles.set(field_accessor, value);
     }
 
-    /// Commits any pending style changes, constructs `E::new()`, and
+    /// Commits any pending style changes, constructs `E::init()`, and
     /// applies the current style chain to it.
     fn create_element<E: Element>(&mut self) -> E {
         if self.fynix.styles.should_commit() {
@@ -123,7 +123,7 @@ impl<W> FynixCtx<'_, '_, W> {
             }
         }
 
-        let mut element = E::new();
+        let mut element = E::init();
         if let Some(id) = &self.prev_style {
             self.fynix.styles.apply(&mut element, id);
         }
@@ -139,12 +139,13 @@ mod tests {
     use field_path::field_accessor;
     use rectree::{Constraint, NodeContext, Size, Vec2};
 
+    use crate::Init;
     use crate::element::ElementBuild;
     use crate::element::layout::ElementNodes;
 
     use super::*;
 
-    #[derive(Element, Default, Clone)]
+    #[derive(Init, Element, Clone)]
     struct Label {
         pub text: &'static str,
     }
@@ -160,7 +161,7 @@ mod tests {
         }
     }
 
-    #[derive(Element, Clone)]
+    #[derive(Init, Element, Clone)]
     struct Vertical {
         #[elem(children)]
         children: Vec<ElementId>,

--- a/crates/fynix/src/element.rs
+++ b/crates/fynix/src/element.rs
@@ -132,10 +132,10 @@ macro_rules! register_element {
             }
         }
 
-        impl $crate::Init for $new_type {
+        impl $crate::init::Init for $new_type {
             #[inline]
             fn init() -> Self {
-                Self($crate::Init::init())
+                Self($crate::init::Init::init())
             }
         }
 

--- a/crates/fynix/src/element.rs
+++ b/crates/fynix/src/element.rs
@@ -4,6 +4,7 @@ use typeslot::{SlotGroup, TypeSlot};
 
 use crate::element::layout::ElementNodes;
 use crate::element::meta::ElementMetas;
+use crate::init::Init;
 
 pub use fynix_macros::{Element, ElementSlot, ElementTemplate};
 
@@ -18,16 +19,6 @@ pub use table::ElementTable;
 /// Marker type for the element slot group.
 #[derive(SlotGroup)]
 pub struct ElementGroup;
-
-/// Constructs a default (unstyled) instance of an element.
-///
-/// Derived by `#[derive(Element)]` - calls `Default::default()` unless
-/// overridden with `#[element(new = my_fn)]`.
-pub trait ElementNew {
-    fn new() -> Self
-    where
-        Self: Sized;
-}
 
 /// Enumerates the children of an element.
 ///
@@ -83,12 +74,12 @@ pub trait ElementBuild {
 
 /// Marker trait for element template types.
 ///
-/// Use `#[derive(ElementTemplate)]` to implement this and the
+/// Use `#[derive(Init, ElementTemplate)]` to implement this and the
 /// associated supertraits automatically.
 ///
 /// Use this for generic types, for non-generic types use [`Element`].
 pub trait ElementTemplate:
-    ElementNew + ElementChildren + ElementBuild + 'static
+    Init + ElementChildren + ElementBuild + 'static
 {
 }
 
@@ -141,10 +132,10 @@ macro_rules! register_element {
             }
         }
 
-        impl $crate::element::ElementNew for $new_type {
+        impl $crate::Init for $new_type {
             #[inline]
-            fn new() -> Self {
-                Self($crate::element::ElementNew::new())
+            fn init() -> Self {
+                Self($crate::Init::init())
             }
         }
 

--- a/crates/fynix/src/init.rs
+++ b/crates/fynix/src/init.rs
@@ -1,0 +1,15 @@
+pub use fynix_macros::Init;
+
+/// Constructs a "blank" instance of a type before styles are applied.
+///
+/// Implement this (or derive it with `#[derive(Init)]`) alongside
+/// `ElementBuild` and `ElementChildren` to satisfy the `ElementTemplate`
+/// bound.
+///
+/// Unlike `Default`, `init` is the designated hook for per-field
+/// initialization values declared via `#[init = expr]`.
+pub trait Init {
+    fn init() -> Self
+    where
+        Self: Sized;
+}

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -25,8 +25,6 @@ pub mod resource;
 pub mod style;
 pub mod type_table;
 
-pub use init::Init;
-
 mod id;
 
 /// Initializes the Fynix framework.

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -20,9 +20,12 @@ pub use typeslot;
 
 pub mod ctx;
 pub mod element;
+pub mod init;
 pub mod resource;
 pub mod style;
 pub mod type_table;
+
+pub use init::Init;
 
 mod id;
 

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -6,6 +6,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use fynix::Fynix;
+use fynix::Init;
 use fynix::element::layout::ElementNodes;
 use fynix::element::meta::ElementMetas;
 use fynix::element::{
@@ -24,7 +25,7 @@ use parley::{
 };
 use parley::{FontContext, LayoutContext};
 
-#[derive(Element, Debug, Clone, Copy)]
+#[derive(Init, Element, Debug, Clone, Copy)]
 pub struct WindowSize {
     pub size: Size,
     #[elem(children)]
@@ -55,7 +56,7 @@ impl ElementBuild for WindowSize {
     }
 }
 
-#[derive(Element, Debug, Clone)]
+#[derive(Init, Element, Debug, Clone)]
 pub struct Horizontal {
     #[elem(children)]
     children: Vec<ElementId>,
@@ -89,7 +90,7 @@ impl ElementBuild for Horizontal {
     }
 }
 
-#[derive(Element, Debug, Clone)]
+#[derive(Init, Element, Debug, Clone)]
 pub struct Vertical {
     #[elem(children)]
     children: Vec<ElementId>,
@@ -123,7 +124,7 @@ impl ElementBuild for Vertical {
     }
 }
 
-#[derive(Element, Debug, Clone, Copy)]
+#[derive(Init, Element, Debug, Clone, Copy)]
 pub struct Pad {
     pub top: f32,
     pub right: f32,
@@ -205,13 +206,13 @@ impl ElementBuild for Pad {
     }
 }
 
-#[derive(ElementTemplate)]
+#[derive(Init, ElementTemplate)]
 pub struct Button<A: 'static> {
     pub on_click: Option<A>,
-    #[elem(default = Brush::Solid(Color::BLACK))]
+    #[init(Brush::Solid(Color::BLACK))]
     pub fill: Brush,
     pub stroke: Stroke,
-    #[elem(default = Brush::Solid(Color::WHITE))]
+    #[init(Brush::Solid(Color::WHITE))]
     pub stroke_brush: Brush,
     pub corner_radius: f64,
     #[elem(children)]
@@ -268,12 +269,12 @@ impl<A> ElementBuild for Button<A> {
     }
 }
 
-#[derive(Element, Debug, Clone)]
+#[derive(Init, Element, Debug, Clone)]
 pub struct Label {
     pub text: String,
-    #[elem(default = Brush::Solid(Color::WHITE))]
+    #[init(Brush::Solid(Color::WHITE))]
     pub fill: Brush,
-    #[elem(default = 16.0)]
+    #[init(16.0)]
     pub font_size: f32,
     pub font_style: FontStyle,
     pub alignment: Alignment,

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -6,7 +6,6 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use fynix::Fynix;
-use fynix::Init;
 use fynix::element::layout::ElementNodes;
 use fynix::element::meta::ElementMetas;
 use fynix::element::{
@@ -18,6 +17,7 @@ use fynix::imaging::record::{Glyph, Scene, replay_transformed};
 use fynix::imaging::{
     Composite, FillRef, GlyphRunRef, PaintSink, StrokeRef, kurbo,
 };
+use fynix::init::Init;
 use fynix::rectree::{Constraint, NodeContext, Size, Vec2};
 use parley::style::StyleProperty;
 use parley::{

--- a/crates/fynix_macros/src/lib.rs
+++ b/crates/fynix_macros/src/lib.rs
@@ -66,16 +66,16 @@ pub fn derive_element_slot(input: TokenStream) -> TokenStream {
 /// Derives `fynix::Init` for the annotated struct.
 ///
 /// Each field defaults to `Default::default()` unless annotated with
-/// `#[init = expr]`, which substitutes `expr` as the initial value.
+/// `#[init(expr)]`, which substitutes `expr` as the initial value.
 ///
 /// # Example
 ///
 /// ```ignore
 /// #[derive(Init)]
 /// struct Label {
-///     #[init = "hello"]
+///     #[init("hello")]
 ///     text: &'static str,
-///     #[init = 16.0]
+///     #[init(16.0)]
 ///     font_size: f32,
 /// }
 /// ```
@@ -118,7 +118,7 @@ pub fn derive_init(input: TokenStream) -> TokenStream {
     .into()
 }
 
-/// Parses `#[init = expr]` from a field's attributes and returns the
+/// Parses `#[init(expr)]` from a field's attributes and returns the
 /// expression, falling back to `Default::default()`.
 fn init_val_for_field(
     attrs: &[syn::Attribute],
@@ -230,7 +230,7 @@ fn parse_field_attrs(
 /// for the annotated struct. Also derive `Init` for element
 /// initialization. Implement `ElementBuild` manually.
 ///
-/// Only works for non-generic structs — use `#[derive(ElementTemplate)]`
+/// Only works for non-generic structs; use `#[derive(ElementTemplate)]`
 /// for generic structs.
 #[proc_macro_derive(Element, attributes(elem))]
 pub fn derive_element(input: TokenStream) -> TokenStream {

--- a/crates/fynix_macros/src/lib.rs
+++ b/crates/fynix_macros/src/lib.rs
@@ -173,7 +173,8 @@ fn parse_element_attrs(
     for attr in attrs {
         if attr.path().is_ident("elem") {
             attr.parse_nested_meta(|meta| {
-                let key = meta.path.get_ident().map(|i| i.to_string());
+                let key =
+                    meta.path.get_ident().map(|i| i.to_string());
                 match key.as_deref() {
                     Some("children") => {
                         children_fn =
@@ -205,7 +206,8 @@ fn parse_field_attrs(
     for attr in attrs {
         if attr.path().is_ident("elem") {
             attr.parse_nested_meta(|meta| {
-                let key = meta.path.get_ident().map(|i| i.to_string());
+                let key =
+                    meta.path.get_ident().map(|i| i.to_string());
                 match key.as_deref() {
                     Some("children") => {
                         is_children = true;

--- a/crates/fynix_macros/src/lib.rs
+++ b/crates/fynix_macros/src/lib.rs
@@ -63,15 +63,111 @@ pub fn derive_element_slot(input: TokenStream) -> TokenStream {
         .into()
 }
 
+/// Derives `fynix::Init` for the annotated struct.
+///
+/// Each field defaults to `Default::default()` unless annotated with
+/// `#[init = expr]`, which substitutes `expr` as the initial value.
+///
+/// # Example
+///
+/// ```ignore
+/// #[derive(Init)]
+/// struct Label {
+///     #[init = "hello"]
+///     text: &'static str,
+///     #[init = 16.0]
+///     font_size: f32,
+/// }
+/// ```
+#[proc_macro_derive(Init, attributes(init))]
+pub fn derive_init(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+    let fynix = fynix_crate();
+
+    let Data::Struct(s) = &input.data else {
+        return syn::Error::new_spanned(
+            name,
+            "#[derive(Init)] only supports structs",
+        )
+        .to_compile_error()
+        .into();
+    };
+
+    let (impl_generics, ty_generics, where_clause) =
+        input.generics.split_for_impl();
+
+    let init_body = match build_init_body(name, &s.fields) {
+        Ok(b) => b,
+        Err(e) => return e.to_compile_error().into(),
+    };
+
+    quote! {
+        impl #impl_generics #fynix::Init
+            for #name #ty_generics #where_clause
+        {
+            #[inline]
+            fn init() -> Self
+            where
+                Self: ::core::marker::Sized,
+            {
+                #init_body
+            }
+        }
+    }
+    .into()
+}
+
+/// Parses `#[init = expr]` from a field's attributes and returns the
+/// expression, falling back to `Default::default()`.
+fn init_val_for_field(
+    attrs: &[syn::Attribute],
+) -> syn::Result<TokenStream2> {
+    for attr in attrs {
+        if attr.path().is_ident("init") {
+            let expr: Expr = attr.parse_args()?;
+            return Ok(quote! { #expr });
+        }
+    }
+    Ok(quote! { ::core::default::Default::default() })
+}
+
+fn build_init_body(
+    name: &Ident,
+    fields: &Fields,
+) -> syn::Result<TokenStream2> {
+    match fields {
+        Fields::Unit => Ok(quote! { #name }),
+        Fields::Named(f) => {
+            let inits = f
+                .named
+                .iter()
+                .map(|field| {
+                    let ident = field.ident.as_ref().unwrap();
+                    let val = init_val_for_field(&field.attrs)?;
+                    Ok(quote! { #ident: #val })
+                })
+                .collect::<syn::Result<Vec<_>>>()?;
+            Ok(quote! { #name { #(#inits),* } })
+        }
+        Fields::Unnamed(f) => {
+            let inits = f
+                .unnamed
+                .iter()
+                .map(|field| init_val_for_field(&field.attrs))
+                .collect::<syn::Result<Vec<_>>>()?;
+            Ok(quote! { #name(#(#inits),*) })
+        }
+    }
+}
+
 struct ElementAttrs {
-    new_body: Option<Expr>,
     children_fn: Option<Expr>,
 }
 
 fn parse_element_attrs(
     attrs: &[syn::Attribute],
 ) -> syn::Result<ElementAttrs> {
-    let mut new_body = None;
     let mut children_fn = None;
 
     for attr in attrs {
@@ -79,17 +175,13 @@ fn parse_element_attrs(
             attr.parse_nested_meta(|meta| {
                 let key = meta.path.get_ident().map(|i| i.to_string());
                 match key.as_deref() {
-                    Some("new") => {
-                        new_body =
-                            Some(meta.value()?.parse::<Expr>()?);
-                    }
                     Some("children") => {
                         children_fn =
                             Some(meta.value()?.parse::<Expr>()?);
                     }
                     _ => {
                         return Err(meta.error(
-                            "unknown `element` key; expected `new` or `children`",
+                            "unknown `elem` key; expected `children`",
                         ));
                     }
                 }
@@ -98,22 +190,17 @@ fn parse_element_attrs(
         }
     }
 
-    Ok(ElementAttrs {
-        new_body,
-        children_fn,
-    })
+    Ok(ElementAttrs { children_fn })
 }
 
 struct FieldAttrs {
     is_children: bool,
-    default: Option<Expr>,
 }
 
 fn parse_field_attrs(
     attrs: &[syn::Attribute],
 ) -> syn::Result<FieldAttrs> {
     let mut is_children = false;
-    let mut default = None;
 
     for attr in attrs {
         if attr.path().is_ident("elem") {
@@ -123,13 +210,9 @@ fn parse_field_attrs(
                     Some("children") => {
                         is_children = true;
                     }
-                    Some("default") => {
-                        default =
-                            Some(meta.value()?.parse::<Expr>()?);
-                    }
                     _ => {
                         return Err(meta.error(
-                            "unknown `element` key; expected `children` or `default`",
+                            "unknown `elem` key; expected `children`",
                         ));
                     }
                 }
@@ -138,16 +221,15 @@ fn parse_field_attrs(
         }
     }
 
-    Ok(FieldAttrs {
-        is_children,
-        default,
-    })
+    Ok(FieldAttrs { is_children })
 }
 
-/// Derives `ElementNew`, `ElementChildren`, `ElementSlot`, and
-/// `ElementTemplate` for the annotated struct. Implement
-/// `ElementBuild` manually. Only works for non-generic structs -
-/// use `#[derive(ElementTemplate)]` for generic structs.
+/// Derives `ElementChildren`, `ElementSlot`, and `ElementTemplate`
+/// for the annotated struct. Also derive `Init` for element
+/// initialization. Implement `ElementBuild` manually.
+///
+/// Only works for non-generic structs — use `#[derive(ElementTemplate)]`
+/// for generic structs.
 #[proc_macro_derive(Element, attributes(elem))]
 pub fn derive_element(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -181,7 +263,6 @@ pub fn derive_element(input: TokenStream) -> TokenStream {
     };
 
     let ElementTemplateImpls {
-        new_impl,
         children_impl,
         template_impl,
     } = match element_template_impls(
@@ -197,15 +278,16 @@ pub fn derive_element(input: TokenStream) -> TokenStream {
 
     quote! {
         #slot_tokens
-        #new_impl
         #children_impl
         #template_impl
     }
     .into()
 }
 
-/// Derives `ElementNew`, `ElementChildren`, and `ElementTemplate`
-/// for the annotated struct. Implement `ElementBuild` manually.
+/// Derives `ElementChildren` and `ElementTemplate` for the annotated
+/// struct. Also derive `Init` for element initialization. Implement
+/// `ElementBuild` manually.
+///
 /// Call `typeslot::register!(ElementGroup, MyStruct<ConcreteType>)`
 /// for each concrete instantiation to satisfy the `Element` bound.
 #[proc_macro_derive(ElementTemplate, attributes(elem))]
@@ -229,7 +311,6 @@ pub fn derive_element_template(input: TokenStream) -> TokenStream {
     };
 
     let ElementTemplateImpls {
-        new_impl,
         children_impl,
         template_impl,
     } = match element_template_impls(
@@ -244,7 +325,6 @@ pub fn derive_element_template(input: TokenStream) -> TokenStream {
     };
 
     quote! {
-        #new_impl
         #children_impl
         #template_impl
     }
@@ -254,7 +334,6 @@ pub fn derive_element_template(input: TokenStream) -> TokenStream {
 struct FieldInfo {
     ident: Option<Ident>,
     is_children: bool,
-    default: Option<Expr>,
 }
 
 fn parse_fields(fields: &Fields) -> syn::Result<Vec<FieldInfo>> {
@@ -268,14 +347,12 @@ fn parse_fields(fields: &Fields) -> syn::Result<Vec<FieldInfo>> {
         Ok(FieldInfo {
             ident: field.ident.clone(),
             is_children: fa.is_children,
-            default: fa.default,
         })
     })
     .collect()
 }
 
 struct ElementTemplateImpls {
-    new_impl: TokenStream2,
     children_impl: TokenStream2,
     template_impl: TokenStream2,
 }
@@ -298,7 +375,7 @@ fn element_template_impls(
         if children_field.is_some() {
             return Err(syn::Error::new_spanned(
                 ident,
-                "`#[element(children)]` can only be used on one field",
+                "`#[elem(children)]` can only be used on one field",
             ));
         }
         children_field = Some(ident);
@@ -306,45 +383,6 @@ fn element_template_impls(
 
     let (impl_generics, ty_generics, where_clause) =
         generics.split_for_impl();
-
-    let default_val = |info: &FieldInfo| {
-        info.default.as_ref().map(|e| quote! { #e }).unwrap_or_else(
-            || quote! { ::core::default::Default::default() },
-        )
-    };
-
-    let new_body = attrs
-        .new_body
-        .map(|expr| quote! { #expr })
-        .unwrap_or_else(|| match &s.fields {
-            Fields::Unit => quote! { #name },
-            Fields::Named(_) => {
-                let inits = field_infos.iter().map(|info| {
-                    let ident = info.ident.as_ref().unwrap();
-                    let val = default_val(info);
-                    quote! { #ident: #val }
-                });
-                quote! { #name { #(#inits),* } }
-            }
-            Fields::Unnamed(_) => {
-                let inits = field_infos.iter().map(default_val);
-                quote! { #name(#(#inits),*) }
-            }
-        });
-
-    let new_impl = quote! {
-        impl #impl_generics #fynix::element::ElementNew
-            for #name #ty_generics #where_clause
-        {
-            #[inline]
-            fn new() -> Self
-            where
-                Self: ::core::marker::Sized,
-            {
-                #new_body
-            }
-        }
-    };
 
     let children_body = attrs
         .children_fn
@@ -386,7 +424,6 @@ fn element_template_impls(
     };
 
     Ok(ElementTemplateImpls {
-        new_impl,
         children_impl,
         template_impl,
     })

--- a/crates/fynix_macros/src/lib.rs
+++ b/crates/fynix_macros/src/lib.rs
@@ -103,7 +103,7 @@ pub fn derive_init(input: TokenStream) -> TokenStream {
     };
 
     quote! {
-        impl #impl_generics #fynix::Init
+        impl #impl_generics #fynix::init::Init
             for #name #ty_generics #where_clause
         {
             #[inline]


### PR DESCRIPTION
Closes #18

## Summary

- Adds `fynix::Init` trait (`fn init() -> Self`) as the designated hook for constructing a blank element before styles are applied
- Adds `#[derive(Init)]` proc macro with `#[init(expr)]` per-field attribute; falls back to `Default::default()` when absent
- Removes `ElementNew`; `ElementTemplate` supertrait bound updated from `ElementNew` to `Init`
- Updates `register_element!` macro, `FynixCtx::create_element`, and all element definitions
- Migrates `fynix_elements` from `#[elem(default = expr)]` to `#[init(expr)]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)