### PR TITLE
Add `Stylable` blanket trait and soften `FynixCtx::set` constraint (#19)

### DIFF
--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -97,10 +97,6 @@ impl<W> FynixCtx<'_, '_, W> {
     /// Queues a style default: field `T` on type `S` will be set to
     /// `value` for all elements added after this call (within the
     /// current scope).
-    ///
-    /// `S` only needs to implement [`Stylable`] (`Init + 'static`),
-    /// so both element types and plain style structs (e.g. for
-    /// [`Composer`](crate::composer::Composer)) can be targeted.
     pub fn set<S: Stylable, T: StyleValue>(
         &mut self,
         field_accessor: FieldAccessor<S, T>,

--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -2,7 +2,7 @@ use field_path::field_accessor::FieldAccessor;
 
 use crate::Fynix;
 use crate::element::{Element, ElementId};
-use crate::style::{StyleId, StyleValue};
+use crate::style::{Stylable, StyleId, StyleValue};
 
 /// Build-time context for constructing the element tree and declaring
 /// style defaults.
@@ -94,12 +94,16 @@ impl<W> FynixCtx<'_, '_, W> {
         id
     }
 
-    /// Queues a style default: field `T` on element type `E` will be
-    /// set to `value` for all elements added after this call (within
-    /// the current scope).
-    pub fn set<E: Element, T: StyleValue>(
+    /// Queues a style default: field `T` on type `S` will be set to
+    /// `value` for all elements added after this call (within the
+    /// current scope).
+    ///
+    /// `S` only needs to implement [`Stylable`] (`Init + 'static`),
+    /// so both element types and plain style structs (e.g. for
+    /// [`Composer`](crate::composer::Composer)) can be targeted.
+    pub fn set<S: Stylable, T: StyleValue>(
         &mut self,
-        field_accessor: FieldAccessor<E, T>,
+        field_accessor: FieldAccessor<S, T>,
         value: T,
     ) {
         self.fynix.styles.set(field_accessor, value);

--- a/crates/fynix/src/style.rs
+++ b/crates/fynix/src/style.rs
@@ -7,6 +7,7 @@ use field_path::field::UntypedField;
 use hashbrown::{HashMap, HashSet};
 
 use crate::id::{GenId, IdGenerator};
+use crate::init::Init;
 use crate::type_table::TypeTable;
 
 pub mod storage;
@@ -228,6 +229,15 @@ impl UntypedSetStyle {
         }
     }
 }
+
+/// Blanket trait alias for types whose fields can be targeted by `Styles::set`.
+///
+/// Any `Init + 'static` type automatically implements this, allowing both
+/// element types and non-element style structs to be used with the style
+/// system.
+pub trait Stylable: Init + 'static {}
+
+impl<T: Init + 'static> Stylable for T {}
 
 /// Blanket trait alias for values that can be stored as style defaults.
 ///

--- a/crates/fynix/src/style.rs
+++ b/crates/fynix/src/style.rs
@@ -230,16 +230,18 @@ impl UntypedSetStyle {
     }
 }
 
-/// Blanket trait alias for types whose fields can be targeted by `Styles::set`.
+/// Blanket trait alias for types whose fields can be targeted by
+/// [`Styles::set()`].
 ///
-/// Any `Init + 'static` type automatically implements this, allowing both
-/// element types and non-element style structs to be used with the style
-/// system.
+/// Any `Init + 'static` type automatically implements this, allowing
+/// both element types and non-element style structs to be used with
+/// the style system.
 pub trait Stylable: Init + 'static {}
 
 impl<T: Init + 'static> Stylable for T {}
 
-/// Blanket trait alias for values that can be stored as style defaults.
+/// Blanket trait alias for values that can be stored as style
+/// defaults.
 ///
 /// Any `Clone + 'static` type automatically implements this.
 pub trait StyleValue: Clone + 'static {}

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -3,71 +3,8 @@
 | Area                                 | Status                            |
 |--------------------------------------|-----------------------------------|
 | Unit system (`src/unit.rs`)          | Planned, not started              |
-| Element composers                    | Ready to start                    |
 | Interactions & Events                | Planned, not started              |
 | Reactivity (`Signals`)               | Deferred until after first render |
-| `TypeSlot` / typed table opt.        | In progress...                    |
-
----
-
-## Element composers
-
-`Composer<W>` is a trait separate from `Element`. It separates
-required caller inputs from styleable element data:
-
-- The **element** (`Hierarchy`) is a normal `Element` - pure data,
-  styleable via `ctx.set`.
-- The **composer** (`HierarchyComposer`) holds required inputs and
-  builds the element. It is not an `Element` itself.
-
-`ctx.compose()` calls `compose`, applies the style chain to the
-returned element, and inserts it into the tree.
-
-```rust
-pub trait Composer<W> {
-    type Element: Element;
-    fn compose(self, ctx: &mut FynixCtx<W>) -> Self::Element;
-}
-```
-
-### Usage
-
-```rust
-#[derive(Element, Default)]
-struct Hierarchy {
-    font_size: f32,
-    #[children]
-    children: Vec<ElementId>,
-}
-
-struct HierarchyComposer<'a> {
-    filter: &'a str,
-}
-
-impl Composer<BevyWorld> for HierarchyComposer<'_> {
-    type Element = Hierarchy;
-    fn compose(self, ctx: &mut FynixCtx<BevyWorld>) -> Hierarchy {
-        let mut h = Hierarchy::default();
-        for _ in ctx.world.query_filtered(self.filter) {
-            h.children.push(ctx.add::<Label>());
-        }
-        h
-    }
-}
-```
-
-```rust
-fn create_ui(ctx: &mut FynixCtx<BevyWorld>) {
-    ctx.set(field_accessor!(<Hierarchy>::font_size), 24.0);
-    ctx.compose(HierarchyComposer { filter: "enemy" });
-}
-```
-
-### Reactive re-composition
-
-When a signal that scopes a composer's subtree changes, the old
-children are removed and `compose` is re-called with fresh data.
-See the reactive scopes section under Signals.
 
 ---
 
@@ -225,17 +162,3 @@ reactive_scopes: HashMap<SignalId, Vec<ScopeEntry>>
 field signals in-place and re-runs any dirty scope builders, limiting
 re-layout to the affected subtree in both cases.
 
----
-
-## `TypeSlot` - typed table optimisation
-
-This enables faster specialised tables for types known at link time:
-
-- `ElementTable` - replaces `TypeTable<ElementId>` for element storage
-- `InteractionTable` - replaces the interaction handler registry
-- `EventTable` - replaces the outgoing events queue
-
-**Style values remain on `TypeTable`** - style field values are
-arbitrary user types (`f32`, `String`, custom structs) that cannot
-be required to `#[derive(HasSlot)]`. The hashmap stays there. This is
-debatable, we will see for the time being..


### PR DESCRIPTION
Replaces the `Element` bound on `FynixCtx::set` with `Stylable` (`Init + 'static`), allowing non-element style structs to be targeted by the style system, a prerequisite for the `Composer` trait (#17).

Closes #19 