### PR TITLE
Add `Composer` trait with `compose`/`compose_with` on `FynixCtx`

### DIFF
--- a/crates/fynix/src/composer.rs
+++ b/crates/fynix/src/composer.rs
@@ -1,0 +1,31 @@
+use crate::ctx::FynixCtx;
+use crate::element::ElementId;
+use crate::style::Stylable;
+
+/// Builds a subtree from caller-supplied inputs and a
+/// pre-styled data struct.
+///
+/// Unlike [`Element`](crate::element::Element), a composer is
+/// not stored in the element tree. It may carry lifetime
+/// parameters (e.g. references into the world) because it is
+/// consumed immediately inside [`FynixCtx::compose`].
+///
+/// # Style flow
+///
+/// [`FynixCtx::compose`] creates `Self::Style` via
+/// [`Init`](crate::init::Init), applies the current style chain
+/// to it, then passes the result to [`Composer::compose`].
+/// [`FynixCtx::compose_with`] additionally runs an inline
+/// closure that can override individual fields after the chain
+/// is applied.
+pub trait Composer<W> {
+    type Style: Stylable;
+
+    fn compose(
+        self,
+        style: Self::Style,
+        ctx: &mut FynixCtx<'_, '_, W>,
+    ) -> ElementId
+    where
+        Self: Sized;
+}

--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -1,6 +1,7 @@
 use field_path::field_accessor::FieldAccessor;
 
 use crate::Fynix;
+use crate::composer::Composer;
 use crate::element::{Element, ElementId};
 use crate::style::{Stylable, StyleId, StyleValue};
 
@@ -105,9 +106,56 @@ impl<W> FynixCtx<'_, '_, W> {
         self.fynix.styles.set(field_accessor, value);
     }
 
-    /// Commits any pending style changes, constructs `E::init()`, and
+    /// Runs `composer`, passing it a style instance built from the
+    /// current style chain.
+    ///
+    /// The composer's scope is isolated: any [`Self::set`] calls made
+    /// inside [`Composer::compose`] do not leak into the outer scope.
+    #[must_use]
+    pub fn compose<C: Composer<W>>(
+        &mut self,
+        composer: C,
+    ) -> ElementId {
+        let style = self.create_styled::<C::Style>();
+
+        let prev_style_id = self.prev_style;
+        let primary_style = self.primary_style.take();
+
+        let id = composer.compose(style, self);
+
+        self.prev_style = prev_style_id;
+        self.primary_style = primary_style;
+        self.fynix.styles.clear_builder();
+
+        id
+    }
+
+    /// Like [`Self::compose`], but runs `inline` after the style chain
+    /// is applied, allowing per-call field overrides.
+    #[must_use]
+    pub fn compose_with<C: Composer<W>>(
+        &mut self,
+        composer: C,
+        inline: impl FnOnce(&mut C::Style),
+    ) -> ElementId {
+        let mut style = self.create_styled::<C::Style>();
+        inline(&mut style);
+
+        let prev_style_id = self.prev_style;
+        let primary_style = self.primary_style.take();
+
+        let id = composer.compose(style, self);
+
+        self.prev_style = prev_style_id;
+        self.primary_style = primary_style;
+        self.fynix.styles.clear_builder();
+
+        id
+    }
+
+    /// Commits any pending style changes, constructs `S::init()`, and
     /// applies the current style chain to it.
-    fn create_element<E: Element>(&mut self) -> E {
+    fn create_styled<S: Stylable>(&mut self) -> S {
         if self.fynix.styles.should_commit() {
             let committed_id = self.fynix.styles.current_id();
 
@@ -123,12 +171,16 @@ impl<W> FynixCtx<'_, '_, W> {
             }
         }
 
-        let mut element = E::init();
+        let mut instance = S::init();
         if let Some(id) = &self.prev_style {
-            self.fynix.styles.apply(&mut element, id);
+            self.fynix.styles.apply(&mut instance, id);
         }
 
-        element
+        instance
+    }
+
+    fn create_element<E: Element>(&mut self) -> E {
+        self.create_styled::<E>()
     }
 }
 
@@ -410,5 +462,85 @@ mod tests {
         // [a] will be removed.
         fynix.remove_element(&elem_a);
         assert_eq!(fynix.styles.styles.len(), 0);
+    }
+
+    #[derive(Init)]
+    struct LabelStyle {
+        pub text: &'static str,
+    }
+
+    struct LabelComposer;
+
+    impl Composer<()> for LabelComposer {
+        type Style = LabelStyle;
+
+        fn compose(
+            self,
+            style: LabelStyle,
+            ctx: &mut FynixCtx<'_, '_, ()>,
+        ) -> ElementId {
+            ctx.add_with::<Label>(|l, _| {
+                l.text = style.text;
+            })
+        }
+    }
+
+    #[test]
+    fn compose_applies_style_chain() {
+        let mut world = ();
+        let mut fynix = Fynix::new();
+        let id = {
+            let mut ctx = fynix.root_ctx(&mut world);
+            ctx.set(
+                field_accessor!(<LabelStyle>::text),
+                "from_chain",
+            );
+            ctx.compose(LabelComposer)
+        };
+
+        let label = fynix.elements.get_typed::<Label>(&id).unwrap();
+        assert_eq!(label.text, "from_chain");
+    }
+
+    #[test]
+    fn compose_with_inline_overrides_chain() {
+        let mut world = ();
+        let mut fynix = Fynix::new();
+        let id = {
+            let mut ctx = fynix.root_ctx(&mut world);
+            ctx.set(
+                field_accessor!(<LabelStyle>::text),
+                "from_chain",
+            );
+            ctx.compose_with(LabelComposer, |s| s.text = "inline")
+        };
+
+        let label = fynix.elements.get_typed::<Label>(&id).unwrap();
+        assert_eq!(label.text, "inline");
+    }
+
+    #[test]
+    fn compose_scope_does_not_leak() {
+        let mut world = ();
+        let mut fynix = Fynix::new();
+        let (inner_id, outer_id) = {
+            let mut ctx = fynix.root_ctx(&mut world);
+            let inner = ctx.compose_with(LabelComposer, |s| {
+                s.text = "inner";
+            });
+            // Styles set inside compose must not affect elements added
+            // after it returns.
+            let outer = ctx.add_with::<Label>(|l, _| {
+                l.text = "outer";
+            });
+            (inner, outer)
+        };
+
+        let inner =
+            fynix.elements.get_typed::<Label>(&inner_id).unwrap();
+        let outer =
+            fynix.elements.get_typed::<Label>(&outer_id).unwrap();
+        assert_eq!(inner.text, "inner");
+        assert_eq!(outer.text, "outer");
     }
 }

--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -51,7 +51,7 @@ impl<W> FynixCtx<'_, '_, W> {
     /// `primary_style` is `None`
     #[must_use]
     pub fn add<E: Element>(&mut self) -> ElementId {
-        let element = self.create_element::<E>();
+        let element = self.create_styled::<E>();
         self.fynix.elements.add(element, None)
     }
 
@@ -72,7 +72,7 @@ impl<W> FynixCtx<'_, '_, W> {
         &mut self,
         scope: impl FnOnce(&mut E, &mut Self),
     ) -> ElementId {
-        let mut element = self.create_element::<E>();
+        let mut element = self.create_styled::<E>();
 
         let prev_style_id = self.prev_style;
         let primary_style = self.primary_style.take();
@@ -177,10 +177,6 @@ impl<W> FynixCtx<'_, '_, W> {
         }
 
         instance
-    }
-
-    fn create_element<E: Element>(&mut self) -> E {
-        self.create_styled::<E>()
     }
 }
 

--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -55,44 +55,18 @@ impl<W> FynixCtx<'_, '_, W> {
         self.fynix.elements.add(element, None)
     }
 
-    /// Like [`Self::add`], but also runs `scope` for inline mutations and
-    /// nested element additions.
-    ///
-    /// The outer `prev_style` is restored after `scope` returns, so
-    /// any [`Self::set`] calls inside `scope` do not affect elements
-    /// added after this call.
-    ///
-    /// The element's `primary_style` is set to the first style
-    /// committed inside the closure.
-    ///
-    /// When the element is removed, that style and all its descendants
-    /// are also removed.
+    /// Like [`Self::add`], but also runs `scope` for inline mutations
+    /// and nested element additions.
     #[must_use]
     pub fn add_with<E: Element>(
         &mut self,
         scope: impl FnOnce(&mut E, &mut Self),
     ) -> ElementId {
         let mut element = self.create_styled::<E>();
-
-        let prev_style_id = self.prev_style;
-        let primary_style = self.primary_style.take();
-
-        scope(&mut element, self);
-
-        let id = self
-            .fynix
-            .elements
-            .add(element, self.primary_style.take());
-
-        // Restore pre-closure state.
-        self.prev_style = prev_style_id;
-        self.primary_style = primary_style;
-
-        // Clears all style leftovers to prevent them from leaking
-        // outside the scope.
-        self.fynix.styles.clear_builder();
-
-        id
+        self.style_scoped(|ctx| {
+            scope(&mut element, ctx);
+            ctx.fynix.elements.add(element, ctx.primary_style.take())
+        })
     }
 
     /// Queues a style default: field `T` on type `S` will be set to
@@ -117,17 +91,7 @@ impl<W> FynixCtx<'_, '_, W> {
         composer: C,
     ) -> ElementId {
         let style = self.create_styled::<C::Style>();
-
-        let prev_style_id = self.prev_style;
-        let primary_style = self.primary_style.take();
-
-        let id = composer.compose(style, self);
-
-        self.prev_style = prev_style_id;
-        self.primary_style = primary_style;
-        self.fynix.styles.clear_builder();
-
-        id
+        self.style_scoped(|ctx| composer.compose(style, ctx))
     }
 
     /// Like [`Self::compose`], but runs `inline` after the style chain
@@ -140,17 +104,34 @@ impl<W> FynixCtx<'_, '_, W> {
     ) -> ElementId {
         let mut style = self.create_styled::<C::Style>();
         inline(&mut style);
+        self.style_scoped(|ctx| composer.compose(style, ctx))
+    }
 
+    /// Saves the current style scope, runs `scope`, then
+    /// restores it.
+    ///
+    /// Prevents style changes made inside `scope` from leaking
+    /// into the outer scope. Any [`Self::set`] calls inside
+    /// `scope` do not affect elements added after this call
+    /// returns. The first style committed inside `scope` becomes
+    /// the element's `primary_style` - when that element is
+    /// removed, its style subtree is also removed.
+    fn style_scoped<T>(
+        &mut self,
+        scope: impl FnOnce(&mut Self) -> T,
+    ) -> T {
         let prev_style_id = self.prev_style;
         let primary_style = self.primary_style.take();
 
-        let id = composer.compose(style, self);
+        let result = scope(self);
 
+        // Restore pre-closure style state.
         self.prev_style = prev_style_id;
         self.primary_style = primary_style;
+        // Clear any uncommitted style changes to prevent leaking.
         self.fynix.styles.clear_builder();
 
-        id
+        result
     }
 
     /// Commits any pending style changes, constructs `S::init()`, and

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -18,12 +18,25 @@ pub use imaging;
 pub use rectree;
 pub use typeslot;
 
+pub mod composer;
 pub mod ctx;
 pub mod element;
 pub mod init;
 pub mod resource;
 pub mod style;
 pub mod type_table;
+
+pub mod prelude {
+    pub use crate::Fynix;
+    pub use crate::composer::Composer;
+    pub use crate::ctx::FynixCtx;
+    pub use crate::element::{
+        Element, ElementBuild, ElementChildren, ElementId,
+        ElementTemplate,
+    };
+    pub use crate::init::Init;
+    pub use crate::style::{Stylable, path};
+}
 
 mod id;
 

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -5,19 +5,15 @@ extern crate alloc;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use fynix::Fynix;
 use fynix::element::layout::ElementNodes;
 use fynix::element::meta::ElementMetas;
-use fynix::element::{
-    Element, ElementBuild, ElementId, ElementTemplate,
-};
 use fynix::imaging::kurbo::{Affine, Stroke};
 use fynix::imaging::peniko::{Brush, BrushRef, Color, Fill, Style};
 use fynix::imaging::record::{Glyph, Scene, replay_transformed};
 use fynix::imaging::{
     Composite, FillRef, GlyphRunRef, PaintSink, StrokeRef, kurbo,
 };
-use fynix::init::Init;
+use fynix::prelude::*;
 use fynix::rectree::{Constraint, NodeContext, Size, Vec2};
 use parley::style::StyleProperty;
 use parley::{

--- a/examples/vello_winit_examples/examples/hello_world.rs
+++ b/examples/vello_winit_examples/examples/hello_world.rs
@@ -1,9 +1,6 @@
 use std::sync::Arc;
 
-use fynix::Fynix;
-use fynix::ctx::FynixCtx;
-use fynix::element::ElementId;
-use fynix::style::path;
+use fynix::prelude::*;
 use fynix_elements::{
     Button, Horizontal, Label, Pad, TextContext, Vertical,
 };
@@ -17,6 +14,12 @@ use winit::event_loop::EventLoop;
 const FONT: &[u8] = include_bytes!("../assets/Inter-Regular.ttf");
 
 fynix::register_element!(EmptyBtn, Button<()>);
+
+fn main() {
+    let event_loop = EventLoop::new().unwrap();
+    let mut app = VelloWinitApp::new(HelloWorld);
+    event_loop.run_app(&mut app).unwrap();
+}
 
 struct HelloWorld;
 
@@ -41,8 +44,6 @@ impl FynixDemo for HelloWorld {
     }
 
     fn build(&mut self, ctx: &mut FynixCtx<()>) -> ElementId {
-        ctx.set(path!(<EmptyBtn>::corner_radius), 8.0);
-
         ctx.add_with::<Pad>(|p, ctx| {
             *p = Pad::all(20.0);
             p.set_child(ctx.add_with::<Vertical>(|v, ctx| {
@@ -84,21 +85,55 @@ impl FynixDemo for HelloWorld {
                     }));
                 }));
 
-                v.add(ctx.add_with::<EmptyBtn>(|b, ctx| {
-                    b.set_child(ctx.add_with::<Pad>(|p, ctx| {
-                        *p = Pad::symmetric(8.0, 16.0);
-                        p.set_child(ctx.add_with::<Label>(|l, _| {
-                            l.text = "Press me!".into();
-                        }));
-                    }));
+                v.add(ctx.compose(TextButton { label: "Press me!" }));
+                v.add(ctx.compose(TextButton {
+                    label: "Other Button!",
+                }));
+                ctx.set(
+                    path!(<TextButtonStyle>::bg_color),
+                    css::GREEN,
+                );
+                v.add(ctx.compose(TextButton {
+                    label: "Green Button?!",
                 }));
             }));
         })
     }
 }
 
-fn main() {
-    let event_loop = EventLoop::new().unwrap();
-    let mut app = VelloWinitApp::new(HelloWorld);
-    event_loop.run_app(&mut app).unwrap();
+#[derive(Init)]
+struct TextButtonStyle {
+    #[init(8.0)]
+    pub corner_radius: f64,
+    #[init(8.0)]
+    pub pad_v: f32,
+    #[init(16.0)]
+    pub pad_h: f32,
+    #[init(Color::BLACK)]
+    pub bg_color: Color,
+}
+
+struct TextButton<'a> {
+    pub label: &'a str,
+}
+
+impl Composer<()> for TextButton<'_> {
+    type Style = TextButtonStyle;
+
+    fn compose(
+        self,
+        style: TextButtonStyle,
+        ctx: &mut FynixCtx<'_, '_, ()>,
+    ) -> ElementId {
+        ctx.add_with::<EmptyBtn>(|b, ctx| {
+            b.corner_radius = style.corner_radius;
+            b.fill = style.bg_color.into();
+            b.set_child(ctx.add_with::<Pad>(|p, ctx| {
+                *p = Pad::symmetric(style.pad_v, style.pad_h);
+                p.set_child(ctx.add_with::<Label>(|l, _| {
+                    l.text = self.label.into();
+                }));
+            }));
+        })
+    }
 }

--- a/examples/vello_winit_examples/examples/hello_world.rs
+++ b/examples/vello_winit_examples/examples/hello_world.rs
@@ -89,13 +89,12 @@ impl FynixDemo for HelloWorld {
                 v.add(ctx.compose(TextButton {
                     label: "Other Button!",
                 }));
-                ctx.set(
-                    path!(<TextButtonStyle>::bg_color),
-                    Some(css::GREEN),
-                );
-                v.add(ctx.compose(TextButton {
-                    label: "Green Button?!",
-                }));
+                v.add(ctx.compose_with(
+                    TextButton {
+                        label: "Green Button?!",
+                    },
+                    |s| s.bg_color = Some(css::GREEN),
+                ));
             }));
         })
     }

--- a/examples/vello_winit_examples/examples/hello_world.rs
+++ b/examples/vello_winit_examples/examples/hello_world.rs
@@ -91,7 +91,7 @@ impl FynixDemo for HelloWorld {
                 }));
                 ctx.set(
                     path!(<TextButtonStyle>::bg_color),
-                    css::GREEN,
+                    Some(css::GREEN),
                 );
                 v.add(ctx.compose(TextButton {
                     label: "Green Button?!",
@@ -109,8 +109,7 @@ struct TextButtonStyle {
     pub pad_v: f32,
     #[init(16.0)]
     pub pad_h: f32,
-    #[init(Color::BLACK)]
-    pub bg_color: Color,
+    pub bg_color: Option<Color>,
 }
 
 struct TextButton<'a> {
@@ -127,7 +126,10 @@ impl Composer<()> for TextButton<'_> {
     ) -> ElementId {
         ctx.add_with::<EmptyBtn>(|b, ctx| {
             b.corner_radius = style.corner_radius;
-            b.fill = style.bg_color.into();
+            if let Some(bg_color) = style.bg_color {
+                b.fill = bg_color.into();
+            }
+
             b.set_child(ctx.add_with::<Pad>(|p, ctx| {
                 *p = Pad::symmetric(style.pad_v, style.pad_h);
                 p.set_child(ctx.add_with::<Label>(|l, _| {


### PR DESCRIPTION
Closes #17 

- Introduces `Composer<W>` in a new `composer` module
- Adds a `prelude` module for common imports.
- Updates `hello_world` example to demonstrate a `TextButton` composer.