### PR TITLE
Add reactive scopes, dirty-driven layout, and FPS demo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,18 +27,6 @@ Fynix is a `no_std` Rust UI framework. The workspace these crates:
 - No `std` imports. Use `alloc::vec::Vec`, `alloc::string::String`,
   `alloc::boxed::Box`, etc.
 - Prefer `hashbrown::{HashMap, HashSet}` over `std::collections`.
-- Must use Module import granulatiy.
-  ```rust
-  // Accepted.
-  use crate::id::{GenId, IdGenerator};
-  use crate::type_table::TypeTable;
-
-  // Unaccepted.
-  use crate::{
-      id::{GenId, IdGenerator},
-      type_table::TypeTable,
-  };
-  ```
 - Use fullstop at the end of sentences in all comments whenever
   possible (including doc comments).
 - Do not write comments after code.
@@ -85,6 +73,10 @@ cargo doc --workspace --all-features --no-deps --document-private-items
   // -----------------------------------------
   // Section Name
   // -----------------------------------------
+  ```
+  Or
+  ```rust
+  // -- Section Name ------
   ```
 
 ---

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1656,7 +1656,7 @@ dependencies = [
 [[package]]
 name = "rectree"
 version = "0.1.0"
-source = "git+https://github.com/voxell-tech/rectree?rev=e9ffbcb#e9ffbcb7294cef3248c30556c597d1102c5d0851"
+source = "git+https://github.com/voxell-tech/rectree?rev=11e802d#11e802d1b9cbcd6cf671371631f53210d1b47043"
 dependencies = [
  "bitflags 2.11.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1656,7 +1656,7 @@ dependencies = [
 [[package]]
 name = "rectree"
 version = "0.1.0"
-source = "git+https://github.com/voxell-tech/rectree?rev=08ddf2a#08ddf2a84e9198980b6ab6c84c2ec25f3a4b3b70"
+source = "git+https://github.com/voxell-tech/rectree?rev=e9ffbcb#e9ffbcb7294cef3248c30556c597d1102c5d0851"
 dependencies = [
  "bitflags 2.11.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ fynix = { version = "0.1.0", path = "crates/fynix" }
 fynix_macros = { version = "0.1.0", path = "crates/fynix_macros" }
 fynix_elements = { version = "0.1.0", path = "crates/fynix_elements" }
 
-rectree = { git = "https://github.com/voxell-tech/rectree", rev = "08ddf2a" }
+rectree = { git = "https://github.com/voxell-tech/rectree", rev = "e9ffbcb" }
 field_path = "0.4.1"
 parley = { version = "0.7.0", default-features = false }
 imaging = { version = "0.0.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ fynix = { version = "0.1.0", path = "crates/fynix" }
 fynix_macros = { version = "0.1.0", path = "crates/fynix_macros" }
 fynix_elements = { version = "0.1.0", path = "crates/fynix_elements" }
 
-rectree = { git = "https://github.com/voxell-tech/rectree", rev = "e9ffbcb" }
+rectree = { git = "https://github.com/voxell-tech/rectree", rev = "11e802d" }
 field_path = "0.4.1"
 parley = { version = "0.7.0", default-features = false }
 imaging = { version = "0.0.1", default-features = false }

--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -3,6 +3,8 @@ use field_path::field_accessor::FieldAccessor;
 use crate::Fynix;
 use crate::composer::Composer;
 use crate::element::{Element, ElementId};
+use crate::init::Init;
+use crate::scope::{BuildFn, ChangedFn, Scope, ScopeElement};
 use crate::style::{Stylable, StyleId, StyleValue};
 
 /// Build-time context for constructing the element tree and declaring
@@ -69,17 +71,6 @@ impl<W> FynixCtx<'_, '_, W> {
         })
     }
 
-    /// Queues a style default: field `T` on type `S` will be set to
-    /// `value` for all elements added after this call (within the
-    /// current scope).
-    pub fn set<S: Stylable, T: StyleValue>(
-        &mut self,
-        field_accessor: FieldAccessor<S, T>,
-        value: T,
-    ) {
-        self.fynix.styles.set(field_accessor, value);
-    }
-
     /// Runs `composer`, passing it a style instance built from the
     /// current style chain.
     ///
@@ -107,6 +98,77 @@ impl<W> FynixCtx<'_, '_, W> {
         self.style_scoped(|ctx| composer.compose(style, ctx))
     }
 
+    /// Queues a style default: field `T` on type `S` will be set to
+    /// `value` for all elements added after this call (within the
+    /// current scope).
+    pub fn set<S: Stylable, T: StyleValue>(
+        &mut self,
+        field_accessor: FieldAccessor<S, T>,
+        value: T,
+    ) {
+        self.fynix.styles.set(field_accessor, value);
+    }
+
+    /// Binds a reactive scope to the element tree.
+    ///
+    /// `build` constructs a subtree and `changed` reports whether the
+    /// state it reads has changed since the last build. A holder
+    /// [`ScopeElement`] owns the subtree, so when `changed` fires the
+    /// backend can rebuild just that subtree in place.
+    ///
+    /// The initial subtree is built immediately, under the current
+    /// style scope. That scope is captured on the [`Scope`] and
+    /// restored on every rebuild, so a rebuilt subtree is styled like
+    /// the first.
+    #[must_use]
+    pub fn reactive(
+        &mut self,
+        changed: ChangedFn<W>,
+        build: BuildFn<W>,
+    ) -> ElementId
+    where
+        W: 'static,
+    {
+        // Build the holder element and its scope together: the
+        // element's id is needed to register the scope, and the
+        // scope's id is needed to construct the element.
+        let style_id = self.prev_style;
+        let element_id = self.fynix.elements.add_with_id(
+            |element_id| {
+                self.fynix.scopes.add(Scope::new(
+                    changed, build, element_id, style_id,
+                ));
+                ScopeElement::init()
+            },
+            None,
+        );
+
+        // Build the initial subtree under the current style scope,
+        // then drop any uncommitted style changes so they do not
+        // leak. The same scope is restored on every rebuild.
+        let child = {
+            let ctx = FynixCtx::new(self.fynix, self.world, style_id);
+            build(ctx)
+        };
+        self.fynix.styles.clear_builder();
+
+        if let Some(child_id) = child
+            && let Some(meta) =
+                self.fynix.elements.metas.get_mut(&child_id)
+        {
+            meta.node.parent_id = Some(element_id);
+        }
+        if let Some(elem) = self
+            .fynix
+            .elements
+            .get_typed_mut::<ScopeElement>(&element_id)
+        {
+            elem.child = child;
+        }
+
+        element_id
+    }
+
     /// Saves the current style scope, runs `scope`, then restores it.
     ///
     /// Prevents style changes made inside `scope` from leaking into
@@ -117,6 +179,7 @@ impl<W> FynixCtx<'_, '_, W> {
     /// [`primary_style`].
     ///
     /// [`primary_style`]: crate::element::meta::ElementMeta::primary_style
+    #[must_use]
     fn style_scoped<T>(
         &mut self,
         scope: impl FnOnce(&mut Self) -> T,
@@ -137,6 +200,7 @@ impl<W> FynixCtx<'_, '_, W> {
 
     /// Commits any pending style changes, constructs `S::init()`, and
     /// applies the current style chain to it.
+    #[must_use]
     fn create_styled<S: Stylable>(&mut self) -> S {
         if self.fynix.styles.should_commit() {
             let committed_id = self.fynix.styles.current_id();

--- a/crates/fynix/src/element/storage.rs
+++ b/crates/fynix/src/element/storage.rs
@@ -1,9 +1,11 @@
+use hashbrown::HashSet;
 use imaging::PaintSink;
 
 use super::Element;
 use super::layout::{ElementNodes, ElementTree};
 use super::meta::{ElementMetas, ElementTypeMetas};
 use crate::resource::Resources;
+use crate::scope::Scopes;
 use crate::style::{StyleId, Styles};
 use crate::type_pool::{ColumnKey, TypePool};
 
@@ -17,6 +19,9 @@ pub struct Elements {
     pub elements: TypePool,
     pub metas: ElementMetas,
     pub type_metas: ElementTypeMetas,
+    /// Elements whose subtree changed and needs re-layout/render,
+    /// e.g. after a reactive scope rebuilt its child.
+    pub dirty_elements: HashSet<ElementId>,
 }
 
 impl Elements {
@@ -25,14 +30,48 @@ impl Elements {
             elements: TypePool::new(),
             metas: ElementMetas::new(),
             type_metas: ElementTypeMetas::new(),
+            dirty_elements: HashSet::new(),
+        }
+    }
+
+    /// Marks an element's subtree dirty so [`Self::layout`] re-lays
+    /// it out on the next call.
+    ///
+    /// Resets the node's layout state here so rectree re-layout the
+    /// subtree.
+    pub fn mark_dirty(&mut self, id: ElementId) {
+        if self.dirty_elements.insert(id)
+            && let Some(meta) = self.metas.get_mut(&id)
+        {
+            meta.node.state.reset();
         }
     }
 
     /// Stores `element`, registers its type if needed, and returns
     /// a fresh [`ElementId`].
+    #[must_use]
     pub fn add<E: Element>(
         &mut self,
         element: E,
+        primary_style: Option<StyleId>,
+    ) -> ElementId {
+        self.add_with_id(
+            #[inline(always)]
+            |_| element,
+            primary_style,
+        )
+    }
+
+    /// Like [`Self::add`], but calls `create` with the element's own
+    /// [`ElementId`] before the element is stored.
+    ///
+    /// Use this when an element must embed a reference to its own id,
+    /// such as a node that links back to a sibling structure keyed on
+    /// that id.
+    #[must_use]
+    pub fn add_with_id<E: Element>(
+        &mut self,
+        create: impl FnOnce(ElementId) -> E,
         primary_style: Option<StyleId>,
     ) -> ElementId {
         let col = self.elements.ensure_column::<E>();
@@ -40,6 +79,7 @@ impl Elements {
 
         let key = self.elements.insert_with_key(|key| {
             let id = ElementId(key);
+            let element = create(id);
 
             // Set parent id on each child's meta node.
             for child_id in element.children() {
@@ -51,7 +91,9 @@ impl Elements {
             element
         });
 
-        ElementId(key)
+        let id = ElementId(key);
+        self.mark_dirty(id);
+        id
     }
 
     /// Returns a type-erased reference to the element.
@@ -93,6 +135,7 @@ impl Elements {
         &mut self,
         id: &ElementId,
         styles: &mut Styles,
+        scopes: &mut Scopes,
     ) -> bool {
         fn remove_recursive(
             id: &ElementId,
@@ -100,6 +143,7 @@ impl Elements {
             type_metas: &ElementTypeMetas,
             elements: &mut TypePool,
             styles: &mut Styles,
+            scopes: &mut Scopes,
             mut has_removed_styles: bool,
         ) -> bool {
             if let Some(meta) = metas.remove(id)
@@ -109,9 +153,14 @@ impl Elements {
                 if !has_removed_styles
                     && let Some(primary_style) = meta.primary_style
                 {
+                    // Drop this element's primary style and its
+                    // descendants in the style tree.
                     has_removed_styles =
                         styles.remove(&primary_style);
                 }
+
+                // Drop any scope this element owns.
+                scopes.remove_for_element(id);
 
                 type_meta.for_each_child_mut(
                     elements,
@@ -123,6 +172,7 @@ impl Elements {
                             type_metas,
                             elements,
                             styles,
+                            scopes,
                             has_removed_styles,
                         );
                     },
@@ -141,6 +191,7 @@ impl Elements {
             &self.type_metas,
             &mut self.elements,
             styles,
+            scopes,
             false,
         )
     }
@@ -177,17 +228,9 @@ impl Elements {
         let _ = meta;
     }
 
-    /// Runs a full three-pass layout cycle on the subtree rooted at
-    /// `id`.
-    ///
-    /// The caller is responsible for setting the node's constraint on
-    /// [`ElementMetas`] before calling this if a specific size is
-    /// required.
-    pub fn layout(
-        &mut self,
-        id: &ElementId,
-        resources: &mut Resources,
-    ) {
+    /// Lays out the subtree of every dirty element, draining the
+    /// dirty set. Nodes are reset when marked dirty, not here.
+    pub fn layout(&mut self, resources: &mut Resources) {
         let tree = ElementTree {
             elements: &self.elements,
             type_metas: &self.type_metas,
@@ -197,7 +240,12 @@ impl Elements {
             metas: &mut self.metas,
             resources,
         };
-        rectree::layout(&tree, &mut nodes, id);
+
+        for id in self.dirty_elements.drain() {
+            if self.elements.contains(&id) {
+                rectree::layout(&tree, &mut nodes, &id);
+            }
+        }
     }
 }
 

--- a/crates/fynix/src/element/storage.rs
+++ b/crates/fynix/src/element/storage.rs
@@ -185,7 +185,12 @@ impl Elements {
             false
         }
 
-        remove_recursive(
+        // Mark the parent as dirty before dropped the child so we can
+        // re-layout the parent's subtree once the child is gone.
+        let parent_id =
+            self.metas.get(id).and_then(|meta| meta.node.parent_id);
+
+        let removed = remove_recursive(
             id,
             &mut self.metas,
             &self.type_metas,
@@ -193,7 +198,13 @@ impl Elements {
             styles,
             scopes,
             false,
-        )
+        );
+
+        if removed && let Some(parent_id) = parent_id {
+            self.mark_dirty(parent_id);
+        }
+
+        removed
     }
 
     /// Renders the subtree rooted at `id` into the `painter`.

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -88,14 +88,7 @@ impl Fynix {
     #[inline]
     pub fn remove_element(&mut self, id: &ElementId) -> bool {
         // Removes the element subtree along with their styles.
-        if !self.elements.remove(
-            id,
-            &mut self.styles,
-            &mut self.scopes,
-        ) {
-            return false;
-        }
-        true
+        self.elements.remove(id, &mut self.styles, &mut self.scopes)
     }
 
     /// Re-runs every reactive scope of world type `W` whose

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -6,7 +6,6 @@ extern crate alloc;
 pub use field_path;
 pub use imaging;
 use imaging::PaintSink;
-pub use rectree;
 
 use crate::ctx::FynixCtx;
 use crate::element::{ElementId, Elements};
@@ -24,6 +23,11 @@ pub mod style;
 pub mod type_pool;
 
 pub mod prelude {
+    // Intentionally exposing only `NodeContext` and hiding
+    // `RectNodes`, `Rectree`, `NodeState`, etc.
+    pub use rectree::NodeContext;
+    pub use rectree::geom::*;
+
     pub use crate::Fynix;
     pub use crate::composer::Composer;
     pub use crate::ctx::FynixCtx;

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -11,6 +11,7 @@ pub use rectree;
 use crate::ctx::FynixCtx;
 use crate::element::{ElementId, Elements};
 use crate::resource::Resources;
+use crate::scope::{ScopeElement, Scopes};
 use crate::style::{StyleId, Styles};
 
 pub mod composer;
@@ -18,6 +19,7 @@ pub mod ctx;
 pub mod element;
 pub mod init;
 pub mod resource;
+pub mod scope;
 pub mod style;
 pub mod type_pool;
 
@@ -45,6 +47,7 @@ pub struct Fynix {
     pub elements: Elements,
     pub styles: Styles,
     pub resources: Resources,
+    pub scopes: Scopes,
 }
 
 impl Fynix {
@@ -53,13 +56,15 @@ impl Fynix {
             elements: Elements::new(),
             styles: Styles::new(),
             resources: Resources::new(),
+            scopes: Scopes::new(),
         }
     }
 
-    /// Runs a full layout cycle on the subtree rooted at `id`.
+    /// Lays out every dirty subtree (see [`Elements::mark_dirty`]),
+    /// draining the dirty set.
     #[inline]
-    pub fn layout(&mut self, id: &ElementId) {
-        self.elements.layout(id, &mut self.resources);
+    pub fn layout(&mut self) {
+        self.elements.layout(&mut self.resources);
     }
 
     /// Renders the subtree rooted at `id` into `sink`.
@@ -79,10 +84,70 @@ impl Fynix {
     #[inline]
     pub fn remove_element(&mut self, id: &ElementId) -> bool {
         // Removes the element subtree along with their styles.
-        if !self.elements.remove(id, &mut self.styles) {
+        if !self.elements.remove(
+            id,
+            &mut self.styles,
+            &mut self.scopes,
+        ) {
             return false;
         }
         true
+    }
+
+    /// Re-runs every reactive scope of world type `W` whose
+    /// `changed_fn` reports a change, rebuilding its subtree in
+    /// place.
+    ///
+    /// Intended to be called by the backend once per frame.
+    pub fn update_scopes<W: 'static>(&mut self, world: &mut W) {
+        for scope in self.scopes.snapshot_changed::<W>(world) {
+            let element_id = scope.element_id();
+
+            // The holder may have been discarded earlier this flush
+            // by an ancestor scope's rebuild. If so, the scope was
+            // dropped with it, so skip the stale snapshot entry.
+            let Some(old_child) = self
+                .elements
+                .get_typed_mut::<ScopeElement>(&element_id)
+                .map(|elem| elem.child.take())
+            else {
+                continue;
+            };
+
+            if let Some(old_child) = old_child {
+                self.elements.remove(
+                    &old_child,
+                    &mut self.styles,
+                    &mut self.scopes,
+                );
+            }
+
+            // Rebuild under the scope's captured style scope, then
+            // drop any uncommitted style changes so they do not leak.
+            let child = {
+                let ctx =
+                    FynixCtx::new(self, world, scope.style_id());
+                scope.build(ctx)
+            };
+            self.styles.clear_builder();
+
+            if let Some(child_id) = child
+                && let Some(meta) =
+                    self.elements.metas.get_mut(&child_id)
+            {
+                meta.node.parent_id = Some(element_id);
+            }
+            if let Some(elem) = self
+                .elements
+                .get_typed_mut::<ScopeElement>(&element_id)
+            {
+                elem.child = child;
+            }
+
+            // Mark the rebuilt subtree dirty so it is re-laid-out
+            // and re-rendered.
+            self.elements.mark_dirty(element_id);
+        }
     }
 
     /// Returns a [`FynixCtx`] rooted at the top of the style

--- a/crates/fynix/src/scope.rs
+++ b/crates/fynix/src/scope.rs
@@ -1,0 +1,168 @@
+use alloc::vec::Vec;
+
+use hashbrown::HashMap;
+use rectree::{Constraint, NodeContext, Size, Vec2};
+
+use crate::ctx::FynixCtx;
+use crate::element::layout::ElementNodes;
+use crate::element::{Element, ElementBuild, ElementId};
+use crate::init::Init;
+use crate::style::StyleId;
+use crate::type_pool::{ColumnKey, TypePool};
+
+pub struct Scopes {
+    scopes: TypePool,
+    /// Reverse index from each holder element to its scope, used to
+    /// remove the scope when the element is removed.
+    by_element: HashMap<ElementId, ScopeId>,
+}
+
+impl Scopes {
+    pub fn new() -> Self {
+        Self {
+            scopes: TypePool::new(),
+            by_element: HashMap::new(),
+        }
+    }
+
+    pub fn add<W: 'static>(&mut self, scope: Scope<W>) -> ScopeId {
+        let element_id = scope.element_id;
+        let scope_id = ScopeId(self.scopes.insert(scope));
+        self.by_element.insert(element_id, scope_id);
+        scope_id
+    }
+
+    /// Removes the scope bound to `element_id`, if any.
+    ///
+    /// A no-op for elements that do not own a scope.
+    pub(crate) fn remove_for_element(
+        &mut self,
+        element_id: &ElementId,
+    ) {
+        if let Some(scope_id) = self.by_element.remove(element_id) {
+            self.scopes.dyn_remove(&scope_id.0);
+        }
+    }
+
+    /// Snapshots every scope of world type `W` whose `changed_fn`
+    /// reports a change against `world`.
+    ///
+    /// [`Scope`] is [`Copy`], so the snapshot detaches the changed
+    /// scopes from the pool, letting the caller borrow the rest of
+    /// `Fynix` while it rebuilds each one.
+    pub(crate) fn snapshot_changed<W: 'static>(
+        &self,
+        world: &W,
+    ) -> Vec<Scope<W>> {
+        self.by_element
+            .values()
+            .filter_map(|id| self.scopes.get::<Scope<W>>(id).copied())
+            .filter(|scope| scope.is_changed(world))
+            .collect()
+    }
+}
+
+impl Default for Scopes {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Init, Element)]
+pub(crate) struct ScopeElement {
+    #[elem(children)]
+    pub(crate) child: Option<ElementId>,
+}
+
+impl ElementBuild for ScopeElement {
+    fn build(
+        &self,
+        _id: &ElementId,
+        constraint: Constraint,
+        nodes: &mut ElementNodes,
+    ) -> Size {
+        // The holder is a pass-through: it takes the size of its
+        // child and positions it at the origin.
+        let Some(child) = &self.child else {
+            return constraint.min;
+        };
+
+        let size = nodes.get_size(child);
+        nodes.set_translation(child, Vec2::ZERO);
+        constraint.constrain(size)
+    }
+}
+
+pub type ChangedFn<W> = fn(&W) -> bool;
+
+pub type BuildFn<W> = fn(FynixCtx<W>) -> Option<ElementId>;
+
+#[derive(Debug)]
+pub struct Scope<W> {
+    /// Function that determines if something has changed and require
+    /// a re-creation of [`ScopeElement::child`].
+    changed_fn: ChangedFn<W>,
+    /// Builds the element for [`ScopeElement::child`].
+    build_fn: BuildFn<W>,
+    /// The element id that holds the [`ScopeElement`].
+    element_id: ElementId,
+    /// Style scope active when the scope was created. Restored on
+    /// each rebuild so the subtree is styled like its first build.
+    style_id: Option<StyleId>,
+}
+
+impl<W> Scope<W> {
+    pub(crate) fn new(
+        changed_fn: ChangedFn<W>,
+        build_fn: BuildFn<W>,
+        element_id: ElementId,
+        style_id: Option<StyleId>,
+    ) -> Self {
+        Self {
+            changed_fn,
+            build_fn,
+            element_id,
+            style_id,
+        }
+    }
+
+    pub(crate) fn element_id(&self) -> ElementId {
+        self.element_id
+    }
+
+    pub(crate) fn style_id(&self) -> Option<StyleId> {
+        self.style_id
+    }
+
+    pub fn is_changed(&self, world: &W) -> bool {
+        (self.changed_fn)(world)
+    }
+
+    pub fn build(&self, ctx: FynixCtx<W>) -> Option<ElementId> {
+        (self.build_fn)(ctx)
+    }
+}
+
+impl<W> Copy for Scope<W> {}
+
+impl<W> Clone for Scope<W> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+/// Generational ID for scope instances.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ScopeId(ColumnKey);
+
+impl ScopeId {
+    /// A sentinel id that will never refer to a live scope.
+    pub const PLACEHOLDER: Self = Self(ColumnKey::PLACEHOLDER);
+}
+
+impl core::ops::Deref for ScopeId {
+    type Target = ColumnKey;
+    fn deref(&self) -> &ColumnKey {
+        &self.0
+    }
+}

--- a/crates/fynix/src/scope.rs
+++ b/crates/fynix/src/scope.rs
@@ -69,7 +69,7 @@ impl Default for Scopes {
 }
 
 #[derive(Init, Element)]
-pub(crate) struct ScopeElement {
+pub struct ScopeElement {
     #[elem(children)]
     pub(crate) child: Option<ElementId>,
 }

--- a/crates/fynix/src/style.rs
+++ b/crates/fynix/src/style.rs
@@ -98,6 +98,7 @@ impl StyleBuilder {
     }
 
     /// Consumes the builder and produces a committed [`Style`].
+    #[must_use]
     fn build(self, parent_id: Option<StyleId>) -> Style {
         let mut index_map = HashMap::new();
         let mut all_fields = Vec::new();

--- a/crates/fynix/src/style/storage.rs
+++ b/crates/fynix/src/style/storage.rs
@@ -27,7 +27,7 @@ pub struct Styles {
     /// inheritance chain via their `parent_id`.
     pub styles: HashMap<StyleId, Style>,
     /// Accumulates field changes for the current (open) style node
-    /// until the next [`commit_styles`](Styles::commit_styles) call.
+    /// until the next [`Self::commit_styles`] call.
     style_builder: StyleBuilder,
     /// The ID of the open style node currently being built.
     current_id: StyleId,
@@ -68,8 +68,7 @@ impl Styles {
     /// node and advances to a fresh [`StyleId`].
     ///
     /// `parent_id` links the new node into the inheritance chain so
-    /// that [`apply`](Styles::apply) can walk up to ancestor
-    /// defaults.
+    /// that [`Self::apply`] can walk up to ancestor defaults.
     ///
     /// `is_nested` controls which child slot on the parent is used:
     /// `true` sets `nested_child` (one scope deeper), `false` sets

--- a/crates/fynix/src/type_pool.rs
+++ b/crates/fynix/src/type_pool.rs
@@ -86,6 +86,13 @@ impl TypePool {
         }
     }
 
+    pub fn contains(&self, col_key: &ColumnKey) -> bool {
+        self.columns
+            .get(col_key.col.index())
+            .map(|c| c.dyn_contains(&col_key.key))
+            .unwrap_or_default()
+    }
+
     /// Inserts `value` and returns a [`ColumnKey`] identifying it.
     pub fn insert<T: 'static>(&mut self, value: T) -> ColumnKey {
         self.insert_with_key(
@@ -205,6 +212,9 @@ mod any_sparse_map {
         ///
         /// Returns `true` if an entry was present and removed.
         fn dyn_remove(&mut self, key: &Key) -> bool;
+
+        /// Returns `true` if an entry was present.
+        fn dyn_contains(&self, key: &Key) -> bool;
     }
 
     impl<T: 'static> AnySparseMap for SparseMap<T> {
@@ -214,6 +224,10 @@ mod any_sparse_map {
 
         fn dyn_remove(&mut self, key: &Key) -> bool {
             self.remove(key).is_some()
+        }
+
+        fn dyn_contains(&self, key: &Key) -> bool {
+            self.contains(key)
         }
     }
 

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -14,7 +14,6 @@ use fynix::imaging::{
     Composite, FillRef, GlyphRunRef, PaintSink, StrokeRef, kurbo,
 };
 use fynix::prelude::*;
-use fynix::rectree::{Constraint, NodeContext, Size, Vec2};
 pub use parley;
 use parley::style::StyleProperty;
 use parley::{

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -4,7 +4,8 @@
 |--------------------------------------|-----------------------------------|
 | Unit system (`src/unit.rs`)          | Planned, not started              |
 | Interactions & Events                | Planned, not started              |
-| Reactivity (`Signals`)               | Deferred until after first render |
+| Reactive scopes (`ctx.reactive`)     | Implemented                       |
+| Field bindings (`Bindings`)          | Planned, not started              |
 
 ---
 
@@ -74,11 +75,11 @@ fn process(fynix: Res<Fynix>, mut commands: Commands) {
 }
 
 // Example consumer system.
-fn system(events: Res<Events>, signals: ResMut<Signals>) {
+fn system(events: Res<Events>, bindings: ResMut<Bindings>) {
     for msg in events.iter::<Increment>() {}
 
     for msg in events.iter::<Decrement>() {
-        signals.set(..);
+        bindings.set(..);
     }
 }
 
@@ -97,68 +98,51 @@ type.
 
 ---
 
-## Signals
+## Bindings
 
-Signals are reactive bindings from an external value to an element
-field. `SignalId` is a plain type alias (same pattern as `ElementId`),
-not a typed wrapper - type safety comes from the accessor at binding
-time.
+A binding connects an external value to an element field. `BindingId`
+is a plain type alias (same pattern as `ElementId`), not a typed
+wrapper - type safety comes from the accessor at binding time.
 
-`Fynix` gains a `signals: Signals` field:
+`Fynix` gains a `bindings: Bindings` field:
 
 ```
-Signals
-- values: TypeTable<SignalId>
-    - current value per (SignalId, T)
-- targets: HashMap<SignalId, (ElementId, UntypedAccessor)>
-    - which element field each signal writes to
-- dirty: HashSet<SignalId>
+Bindings
+- values: TypeTable<BindingId>
+    - current value per (BindingId, T)
+- targets: HashMap<BindingId, (ElementId, UntypedAccessor)>
+    - which element field each binding writes to
+- dirty: HashSet<BindingId>
     - changed since last flush
 - layout_dirty: HashSet<ElementId>
     - populated during flush, consumed by the backend
 - render_dirty: HashSet<ElementId>
     - populated during flush, consumed by the backend
-- id_generator: SignalIdGenerator
+- id_generator: BindingIdGenerator
 ```
 
-Two kinds of signals:
-
-**Field signals** - bind a signal to a single element field. Flushing
-writes the value directly into `Elements` in-place, then marks the
-element layout/render dirty:
+**Field bindings** - bind a single element field to an external value.
+Flushing writes the value directly into `Elements` in-place, then
+marks the element layout/render dirty:
 
 ```rust
-let label_text: SignalId = ctx.signal(
+let label_text: BindingId = ctx.bind(
     field_accessor!(<Label>::text),
     "hello".to_string(),
 );
 
 // From outside Fynix:
-fynix.signals.set(label_text, "world".to_string());
+fynix.bindings.set(label_text, "world".to_string());
 ```
 
-**Reactive scopes** - bind a signal to a subtree builder closure.
-When the signal changes, the old children of the scope root are
-removed and the closure re-runs with fresh state:
+A `flush_bindings()` would be called by the backend each frame to
+apply field bindings in-place, limiting re-layout to the affected
+subtree.
 
-```rust
-ctx.add_with::<Vertical>(|v, ctx| {
-    ctx.reactive(items_signal, |items, ctx| {
-        for item in items {
-            v.add(ctx.add::<Label>());
-        }
-    });
-});
-```
-
-Scope entries are stored on `Fynix`:
-
-```
-reactive_scopes: HashMap<SignalId, Vec<ScopeEntry>>
-    ScopeEntry { root: ElementId, rebuild: Box<dyn FnMut(...)> }
-```
-
-`flush_signals()` is called by the backend each frame. It applies
-field signals in-place and re-runs any dirty scope builders, limiting
-re-layout to the affected subtree in both cases.
+> **Reactive scopes** (the change-detection counterpart) are already
+> implemented as `ctx.reactive(changed_fn, build_fn)` +
+> `Fynix::update_scopes::<W>(world)`, backed by `Scopes` / `Scope` /
+> `ScopeElement` and `Elements::dirty_elements`. The remaining
+> dirty-propagation and depth-ordering work is tracked in issue #38.
+> See `crates/fynix/src/scope.rs`.
 

--- a/examples/vello_winit_examples/examples/hello_world.rs
+++ b/examples/vello_winit_examples/examples/hello_world.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use fynix::prelude::*;
 use fynix_elements::parley::FontStyle;
@@ -21,9 +22,33 @@ fn main() {
 
 struct HelloWorld;
 
+/// Demo world: the current FPS, recomputed each frame from the
+/// frame delta.
+#[derive(Default)]
+struct DemoWorld {
+    fps: u32,
+    /// True only on the frame `fps` changed, so the reactive counter
+    /// rebuilds just then.
+    fps_changed: bool,
+}
+
 impl FynixDemo for HelloWorld {
+    type World = DemoWorld;
+
     fn window_title(&self) -> &'static str {
         "Hello, Fynix!"
+    }
+
+    fn update(&mut self, world: &mut DemoWorld, dt: Duration) {
+        world.fps_changed = false;
+        let secs = dt.as_secs_f32();
+        if secs > 0.0 {
+            let fps = (1.0 / secs).round() as u32;
+            if fps != world.fps {
+                world.fps = fps;
+                world.fps_changed = true;
+            }
+        }
     }
 
     fn init(&mut self, fynix: &mut Fynix) {
@@ -41,11 +66,24 @@ impl FynixDemo for HelloWorld {
         }
     }
 
-    fn build(&mut self, ctx: &mut FynixCtx<()>) -> ElementId {
+    fn build(&mut self, ctx: &mut FynixCtx<DemoWorld>) -> ElementId {
         ctx.add_with::<Pad>(|p, ctx| {
             *p = Pad::all(20.0);
             p.set_child(ctx.add_with::<Vertical>(|v, ctx| {
                 ctx.set(path!(<Label>::fill), Color::WHITE.into());
+
+                // Reactive FPS counter: rebuilt only when the value
+                // changes (see `DemoWorld::update`).
+                v.add(ctx.reactive(
+                    |w| w.fps_changed,
+                    |mut ctx| {
+                        let fps = ctx.world.fps;
+                        Some(ctx.add_with::<Label>(|label, _| {
+                            label.text = format!("FPS: {fps}");
+                            label.font_size = 20.0;
+                        }))
+                    },
+                ));
 
                 v.add(ctx.add_with::<Label>(|label, _ctx| {
                     label.text = "Hello, Fynix!".into();
@@ -113,15 +151,15 @@ struct TextButton<'a> {
     pub label: &'a str,
 }
 
-impl Composer<()> for TextButton<'_> {
+impl Composer<DemoWorld> for TextButton<'_> {
     type Style = TextButtonStyle;
 
     fn compose(
         self,
         style: TextButtonStyle,
-        ctx: &mut FynixCtx<'_, '_, ()>,
+        ctx: &mut FynixCtx<'_, '_, DemoWorld>,
     ) -> ElementId {
-        ctx.add_with::<Button<()>>(|b, ctx| {
+        ctx.add_with::<Button<DemoWorld>>(|b, ctx| {
             b.corner_radius = style.corner_radius;
             if let Some(bg_color) = style.bg_color {
                 b.fill = bg_color.into();

--- a/examples/vello_winit_examples/src/lib.rs
+++ b/examples/vello_winit_examples/src/lib.rs
@@ -2,9 +2,7 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use fynix::ctx::FynixCtx;
-use fynix::element::ElementId;
-use fynix::{Fynix, rectree};
+use fynix::prelude::*;
 use fynix_elements::WindowSize;
 use imaging_vello::VelloSceneSink;
 use vello::kurbo::Rect;
@@ -116,8 +114,7 @@ impl<D: FynixDemo> VelloWinitApp<'_, D> {
         // Resize the root only when the window size changes, marking
         // it dirty so the whole tree re-lays out then (and on the
         // first frame).
-        let size =
-            rectree::Size::new(phys.width as f32, phys.height as f32);
+        let size = Size::new(phys.width as f32, phys.height as f32);
         let resized = self
             .fynix
             .elements

--- a/examples/vello_winit_examples/src/lib.rs
+++ b/examples/vello_winit_examples/src/lib.rs
@@ -1,5 +1,6 @@
 use std::num::NonZeroUsize;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use fynix::ctx::FynixCtx;
 use fynix::element::ElementId;
@@ -19,6 +20,10 @@ use winit::event_loop::ActiveEventLoop;
 use winit::window::Window;
 
 pub trait FynixDemo {
+    /// World state passed to [`Self::build`] and advanced each frame
+    /// in [`Self::update`]. Reactive scopes read from it.
+    type World: Default + 'static;
+
     fn window_title(&self) -> &'static str {
         "Fynix"
     }
@@ -29,13 +34,20 @@ pub trait FynixDemo {
 
     fn init(&mut self, _fynix: &mut Fynix) {}
 
-    fn build(&mut self, ctx: &mut FynixCtx<()>) -> ElementId;
+    /// Advances world state before reactive scopes are updated.
+    /// `dt` is the time elapsed since the previous frame.
+    fn update(&mut self, _world: &mut Self::World, _dt: Duration) {}
+
+    fn build(&mut self, ctx: &mut FynixCtx<Self::World>)
+    -> ElementId;
 }
 
 pub struct VelloWinitApp<'s, D: FynixDemo> {
     fynix: Fynix,
     root_id: ElementId,
     demo: D,
+    world: D::World,
+    last_frame: Instant,
     context: RenderContext,
     renderer: Option<Renderer>,
     state: RenderState<'s>,
@@ -55,7 +67,7 @@ impl<D: FynixDemo> VelloWinitApp<'_, D> {
         let mut fynix = Fynix::new();
         demo.init(&mut fynix);
 
-        let mut world = ();
+        let mut world = D::World::default();
         let root_id = {
             let mut ctx = fynix.root_ctx(&mut world);
             ctx.add_with::<WindowSize>(|w, ctx| {
@@ -67,6 +79,8 @@ impl<D: FynixDemo> VelloWinitApp<'_, D> {
             fynix,
             root_id,
             demo,
+            world,
+            last_frame: Instant::now(),
             context: RenderContext::new(),
             renderer: None,
             state: RenderState::Suspended(None),
@@ -99,24 +113,34 @@ impl<D: FynixDemo> VelloWinitApp<'_, D> {
             );
         }
 
-        if let Some(root) = self
+        // Resize the root only when the window size changes, marking
+        // it dirty so the whole tree re-lays out then (and on the
+        // first frame).
+        let size =
+            rectree::Size::new(phys.width as f32, phys.height as f32);
+        let resized = self
             .fynix
             .elements
             .get_typed_mut::<WindowSize>(&self.root_id)
-        {
-            root.size = rectree::Size::new(
-                phys.width as f32,
-                phys.height as f32,
-            );
+            .is_some_and(|root| {
+                let changed = root.size.width != size.width
+                    || root.size.height != size.height;
+                root.size = size;
+                changed
+            });
+        if resized {
+            self.fynix.elements.mark_dirty(self.root_id);
         }
 
-        if let Some(meta) =
-            self.fynix.elements.metas.get_mut(&self.root_id)
-        {
-            meta.node.state.reset();
-        }
+        // Advance world state with this frame's delta, then rebuild
+        // any reactive scopes whose inputs changed, before layout.
+        let now = Instant::now();
+        let dt = now.duration_since(self.last_frame);
+        self.last_frame = now;
+        self.demo.update(&mut self.world, dt);
+        self.fynix.update_scopes::<D::World>(&mut self.world);
 
-        self.fynix.layout(&self.root_id);
+        self.fynix.layout();
 
         let bounds = Rect::new(
             0.0,


### PR DESCRIPTION
Reactive scopes: `FynixCtx::reactive(changed, build)` registers a `Scope` plus a holder `ScopeElement`, and `Fynix::update_scopes::<W>(world)` re-runs the builder of every scope whose `changed_fn(&W)` fires, restoring the captured style scope and cleaning up discarded nested scopes. `Scopes` stores scopes in a `TypePool` with an element->scope reverse index, so removing an element drops the scope it owns.

Elements: add `add_with_id` (build an element that embeds its own id), a `dirty_elements` set with `mark_dirty`, and a dirty-driven `layout` that lays out each changed subtree instead of always walking from the root.

Bump rectree to e9ffbcb for the non-root layout translation-seed fix.

Demo: `FynixDemo` gains an associated `World` and a per-frame `update(world, dt)` hook; hello_world shows a reactive FPS counter.

https://github.com/user-attachments/assets/a1d71e17-0ac1-46de-9e3b-1e6320742bb5

Closes #4 
Supersedes #10 

## Known Issue

Layout could be performed multiple times redundantly. Will be addressed in #38 