### PR TITLE
Return `ElementHandle` from `add_with`, `compose`, `compose_with`, `reactive`

### DIFF
--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -67,12 +67,13 @@ impl<W> FynixCtx<'_, '_, W> {
     pub fn add_with<E: Element>(
         &mut self,
         scope: impl FnOnce(&mut E, &mut Self),
-    ) -> ElementId {
+    ) -> ElementHandle<'_> {
         let mut element = self.create_styled::<E>();
-        self.style_scoped(|ctx| {
+        let id = self.style_scoped(|ctx| {
             scope(&mut element, ctx);
             ctx.fynix.elements.add(element, ctx.primary_style.take())
-        })
+        });
+        ElementHandle::new(&mut self.fynix.interactions, id)
     }
 
     /// Runs `composer`, passing it a style instance built from the
@@ -84,9 +85,10 @@ impl<W> FynixCtx<'_, '_, W> {
     pub fn compose<C: Composer<W>>(
         &mut self,
         composer: C,
-    ) -> ElementId {
+    ) -> ElementHandle<'_> {
         let style = self.create_styled::<C::Style>();
-        self.style_scoped(|ctx| composer.compose(style, ctx))
+        let id = self.style_scoped(|ctx| composer.compose(style, ctx));
+        ElementHandle::new(&mut self.fynix.interactions, id)
     }
 
     /// Like [`Self::compose`], but runs `inline` after the style
@@ -96,10 +98,11 @@ impl<W> FynixCtx<'_, '_, W> {
         &mut self,
         composer: C,
         inline: impl FnOnce(&mut C::Style),
-    ) -> ElementId {
+    ) -> ElementHandle<'_> {
         let mut style = self.create_styled::<C::Style>();
         inline(&mut style);
-        self.style_scoped(|ctx| composer.compose(style, ctx))
+        let id = self.style_scoped(|ctx| composer.compose(style, ctx));
+        ElementHandle::new(&mut self.fynix.interactions, id)
     }
 
     /// Queues a style default: field `T` on type `S` will be set to
@@ -129,7 +132,7 @@ impl<W> FynixCtx<'_, '_, W> {
         &mut self,
         changed: ChangedFn<W>,
         build: BuildFn<W>,
-    ) -> ElementId
+    ) -> ElementHandle<'_>
     where
         W: 'static,
     {
@@ -170,7 +173,7 @@ impl<W> FynixCtx<'_, '_, W> {
             elem.child = child;
         }
 
-        element_id
+        ElementHandle::new(&mut self.fynix.interactions, element_id)
     }
 
     /// Saves the current style scope, runs `scope`, then restores it.
@@ -348,6 +351,7 @@ mod tests {
             ctx.add_with::<Vertical>(|v, ctx| {
                 v.add(ctx.add::<Label>());
             })
+            .id()
         };
 
         let vertical =
@@ -376,6 +380,7 @@ mod tests {
                 v.add(inner_id);
                 v.add(ctx.add::<Label>());
             })
+            .id()
         };
 
         let vertical =
@@ -399,6 +404,7 @@ mod tests {
                 ctx.set(field_accessor!(<Label>::text), "child");
                 v.add(ctx.add::<Label>());
             })
+            .id()
         };
 
         let vertical =
@@ -442,7 +448,8 @@ mod tests {
                                 );
                                 v.add({
                                     elem_e = ctx
-                                        .add_with::<Label>(|_, _| {});
+                                        .add_with::<Label>(|_, _| {})
+                                        .id();
                                     elem_e
                                 });
 
@@ -454,13 +461,16 @@ mod tests {
                                     elem_f = ctx.add::<Label>().id();
                                     elem_f
                                 });
-                            });
+                            })
+                            .id();
                         elem_d
                     });
-                });
+                })
+                .id();
                 elem_c
             });
-        });
+        })
+        .id();
 
         let mut len = fynix.styles.styles.len();
         // Verify we have 6 styles [z, a, b, c, d].
@@ -526,11 +536,13 @@ mod tests {
                     elem_b = ctx.add_with::<Vertical>(|v, ctx| {
                         ctx.set(field_accessor!(<Label>::text), "a");
                         v.add(ctx.add::<Label>());
-                    });
+                    })
+                    .id();
                     elem_b
                 })
             }));
-        });
+        })
+        .id();
 
         // Verify we have 1 style [a].
         assert_eq!(fynix.styles.styles.len(), 1);
@@ -570,6 +582,7 @@ mod tests {
             ctx.add_with::<Label>(|l, _| {
                 l.text = style.text;
             })
+            .id()
         }
     }
 
@@ -583,7 +596,7 @@ mod tests {
                 field_accessor!(<LabelStyle>::text),
                 "from_chain",
             );
-            ctx.compose(LabelComposer)
+            ctx.compose(LabelComposer).id()
         };
 
         let label = fynix.elements.get_typed::<Label>(&id).unwrap();
@@ -601,6 +614,7 @@ mod tests {
                 "from_chain",
             );
             ctx.compose_with(LabelComposer, |s| s.text = "inline")
+                .id()
         };
 
         let label = fynix.elements.get_typed::<Label>(&id).unwrap();
@@ -615,12 +629,12 @@ mod tests {
             let mut ctx = fynix.root_ctx(&mut world);
             let inner = ctx.compose_with(LabelComposer, |s| {
                 s.text = "inner";
-            });
+            }).id();
             // Styles set inside compose must not affect elements
             // added after it returns.
             let outer = ctx.add_with::<Label>(|l, _| {
                 l.text = "outer";
-            });
+            }).id();
             (inner, outer)
         };
 

--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -87,7 +87,8 @@ impl<W> FynixCtx<'_, '_, W> {
         composer: C,
     ) -> ElementHandle<'_> {
         let style = self.create_styled::<C::Style>();
-        let id = self.style_scoped(|ctx| composer.compose(style, ctx));
+        let id =
+            self.style_scoped(|ctx| composer.compose(style, ctx));
         ElementHandle::new(&mut self.fynix.interactions, id)
     }
 
@@ -101,7 +102,8 @@ impl<W> FynixCtx<'_, '_, W> {
     ) -> ElementHandle<'_> {
         let mut style = self.create_styled::<C::Style>();
         inline(&mut style);
-        let id = self.style_scoped(|ctx| composer.compose(style, ctx));
+        let id =
+            self.style_scoped(|ctx| composer.compose(style, ctx));
         ElementHandle::new(&mut self.fynix.interactions, id)
     }
 
@@ -428,49 +430,62 @@ mod tests {
         let mut elem_d = ElementId::PLACEHOLDER;
         let mut elem_e = ElementId::PLACEHOLDER;
         let mut elem_f = ElementId::PLACEHOLDER;
-        let elem_b = ctx.add_with::<Vertical>(|v, ctx| {
-            ctx.set(field_accessor!(<Label>::text), "a");
+        let elem_b = ctx
+            .add_with::<Vertical>(|v, ctx| {
+                ctx.set(field_accessor!(<Label>::text), "a");
 
-            v.add({
-                elem_c = ctx.add_with::<Vertical>(|v, ctx| {
-                    ctx.set(field_accessor!(<Label>::text), "b");
+                v.add({
+                    elem_c = ctx
+                        .add_with::<Vertical>(|v, ctx| {
+                            ctx.set(
+                                field_accessor!(<Label>::text),
+                                "b",
+                            );
 
-                    v.add({
-                        elem_d =
-                            ctx.add_with::<Vertical>(|v, ctx| {
-                                // Trigger `create_element` without
-                                // any prior style.
-                                v.add(ctx.add::<Label>());
+                            v.add({
+                                elem_d =
+                                    ctx.add_with::<Vertical>(
+                                        |v, ctx| {
+                                            // Trigger `create_element` without
+                                            // any prior style.
+                                            v.add(ctx.add::<Label>());
 
-                                ctx.set(
-                                    field_accessor!(<Label>::text),
-                                    "c",
-                                );
-                                v.add({
-                                    elem_e = ctx
+                                            ctx.set(
+                                                field_accessor!(
+                                                    <Label>::text
+                                                ),
+                                                "c",
+                                            );
+                                            v.add({
+                                                elem_e = ctx
                                         .add_with::<Label>(|_, _| {})
                                         .id();
-                                    elem_e
-                                });
+                                                elem_e
+                                            });
 
-                                ctx.set(
-                                    field_accessor!(<Label>::text),
-                                    "d",
-                                );
-                                v.add({
-                                    elem_f = ctx.add::<Label>().id();
-                                    elem_f
-                                });
-                            })
-                            .id();
-                        elem_d
-                    });
-                })
-                .id();
-                elem_c
-            });
-        })
-        .id();
+                                            ctx.set(
+                                                field_accessor!(
+                                                    <Label>::text
+                                                ),
+                                                "d",
+                                            );
+                                            v.add({
+                                                elem_f = ctx
+                                                    .add::<Label>()
+                                                    .id();
+                                                elem_f
+                                            });
+                                        },
+                                    )
+                                    .id();
+                                elem_d
+                            });
+                        })
+                        .id();
+                    elem_c
+                });
+            })
+            .id();
 
         let mut len = fynix.styles.styles.len();
         // Verify we have 6 styles [z, a, b, c, d].
@@ -530,19 +545,24 @@ mod tests {
         let mut ctx = fynix.root_ctx(&mut world);
 
         let mut elem_b = ElementId::PLACEHOLDER;
-        let elem_a = ctx.add_with::<Vertical>(|v, ctx| {
-            v.add(ctx.add_with::<Vertical>(|v, ctx| {
-                v.add({
-                    elem_b = ctx.add_with::<Vertical>(|v, ctx| {
-                        ctx.set(field_accessor!(<Label>::text), "a");
-                        v.add(ctx.add::<Label>());
+        let elem_a = ctx
+            .add_with::<Vertical>(|v, ctx| {
+                v.add(ctx.add_with::<Vertical>(|v, ctx| {
+                    v.add({
+                        elem_b = ctx
+                            .add_with::<Vertical>(|v, ctx| {
+                                ctx.set(
+                                    field_accessor!(<Label>::text),
+                                    "a",
+                                );
+                                v.add(ctx.add::<Label>());
+                            })
+                            .id();
+                        elem_b
                     })
-                    .id();
-                    elem_b
-                })
-            }));
-        })
-        .id();
+                }));
+            })
+            .id();
 
         // Verify we have 1 style [a].
         assert_eq!(fynix.styles.styles.len(), 1);
@@ -627,14 +647,18 @@ mod tests {
         let mut fynix = Fynix::new();
         let (inner_id, outer_id) = {
             let mut ctx = fynix.root_ctx(&mut world);
-            let inner = ctx.compose_with(LabelComposer, |s| {
-                s.text = "inner";
-            }).id();
+            let inner = ctx
+                .compose_with(LabelComposer, |s| {
+                    s.text = "inner";
+                })
+                .id();
             // Styles set inside compose must not affect elements
             // added after it returns.
-            let outer = ctx.add_with::<Label>(|l, _| {
-                l.text = "outer";
-            }).id();
+            let outer = ctx
+                .add_with::<Label>(|l, _| {
+                    l.text = "outer";
+                })
+                .id();
             (inner, outer)
         };
 

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -29,8 +29,8 @@ pub struct WindowSize {
 }
 
 impl WindowSize {
-    pub fn set_child(&mut self, id: ElementId) {
-        self.child = Some(id);
+    pub fn set_child(&mut self, id: impl Into<ElementId>) {
+        self.child = Some(id.into());
     }
 }
 
@@ -59,8 +59,8 @@ pub struct Horizontal {
 }
 
 impl Horizontal {
-    pub fn add(&mut self, id: ElementId) -> &mut Self {
-        self.children.push(id);
+    pub fn add(&mut self, id: impl Into<ElementId>) -> &mut Self {
+        self.children.push(id.into());
         self
     }
 }
@@ -93,8 +93,8 @@ pub struct Vertical {
 }
 
 impl Vertical {
-    pub fn add(&mut self, id: ElementId) -> &mut Self {
-        self.children.push(id);
+    pub fn add(&mut self, id: impl Into<ElementId>) -> &mut Self {
+        self.children.push(id.into());
         self
     }
 }
@@ -131,8 +131,8 @@ pub struct Pad {
 }
 
 impl Pad {
-    pub fn set_child(&mut self, id: ElementId) {
-        self.child = Some(id);
+    pub fn set_child(&mut self, id: impl Into<ElementId>) {
+        self.child = Some(id.into());
     }
 
     pub fn new(top: f32, right: f32, bottom: f32, left: f32) -> Self {
@@ -215,8 +215,8 @@ pub struct Button {
 }
 
 impl Button {
-    pub fn set_child(&mut self, id: ElementId) {
-        self.child = Some(id);
+    pub fn set_child(&mut self, id: impl Into<ElementId>) {
+        self.child = Some(id.into());
     }
 }
 

--- a/examples/vello_winit_examples/examples/hello_world.rs
+++ b/examples/vello_winit_examples/examples/hello_world.rs
@@ -81,7 +81,7 @@ impl FynixDemo for HelloWorld {
                         Some(ctx.add_with::<Label>(|label, _| {
                             label.text = format!("FPS: {fps}");
                             label.font_size = 20.0;
-                        }))
+                        }).id())
                     },
                 ));
 
@@ -133,6 +133,7 @@ impl FynixDemo for HelloWorld {
                 ));
             }));
         })
+        .id()
     }
 }
 
@@ -172,5 +173,6 @@ impl Composer<DemoWorld> for TextButton<'_> {
                 }));
             }));
         })
+        .id()
     }
 }

--- a/examples/vello_winit_examples/examples/hello_world.rs
+++ b/examples/vello_winit_examples/examples/hello_world.rs
@@ -78,10 +78,13 @@ impl FynixDemo for HelloWorld {
                     |w| w.fps_changed,
                     |mut ctx| {
                         let fps = ctx.world.fps;
-                        Some(ctx.add_with::<Label>(|label, _| {
-                            label.text = format!("FPS: {fps}");
-                            label.font_size = 20.0;
-                        }).id())
+                        Some(
+                            ctx.add_with::<Label>(|label, _| {
+                                label.text = format!("FPS: {fps}");
+                                label.font_size = 20.0;
+                            })
+                            .id(),
+                        )
                     },
                 ));
 

--- a/examples/vello_winit_examples/src/lib.rs
+++ b/examples/vello_winit_examples/src/lib.rs
@@ -71,6 +71,7 @@ impl<D: FynixDemo> VelloWinitApp<'_, D> {
             ctx.add_with::<WindowSize>(|w, ctx| {
                 w.set_child(demo.build(ctx));
             })
+            .id()
         };
 
         Self {


### PR DESCRIPTION
Element setter/adder methods in `fynix_elements` now accept `impl Into<ElementId>` so `ElementHandle` can be passed directly without calling `.id()`.