### PR TITLE
Change `BuildFn` to take `&mut FynixCtx` instead of by value

### DIFF
--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -154,13 +154,8 @@ impl<W> FynixCtx<'_, '_, W> {
             None,
         );
 
-        // Build the initial subtree under the current style scope,
-        // then drop any uncommitted style changes so they do not
-        // leak. The same scope is restored on every rebuild.
-        let child = {
-            let ctx = FynixCtx::new(self.fynix, self.world, style_id);
-            build(ctx)
-        };
+        // Build the initial subtree under the current style scope.
+        let child = build(self);
         // Clear any uncommitted style changes to prevent leaking.
         self.fynix.styles.clear_builder();
 

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -162,9 +162,9 @@ impl Fynix {
             // Rebuild under the reactive's captured style scope, then
             // drop any uncommitted style changes so they do not leak.
             let child = {
-                let ctx =
+                let mut ctx =
                     FynixCtx::new(self, world, reactive.style_id());
-                reactive.build(ctx)
+                reactive.build(&mut ctx)
             };
             self.styles.clear_builder();
 

--- a/crates/fynix/src/reactive.rs
+++ b/crates/fynix/src/reactive.rs
@@ -99,7 +99,7 @@ impl ElementBuild for ReactiveElement {
 
 pub type ChangedFn<W> = fn(&W) -> bool;
 
-pub type BuildFn<W> = fn(FynixCtx<W>) -> Option<ElementId>;
+pub type BuildFn<W> = fn(&mut FynixCtx<W>) -> Option<ElementId>;
 
 #[derive(Debug)]
 pub struct Reactive<W> {
@@ -142,7 +142,7 @@ impl<W> Reactive<W> {
         (self.changed_fn)(world)
     }
 
-    pub fn build(&self, ctx: FynixCtx<W>) -> Option<ElementId> {
+    pub fn build(&self, ctx: &mut FynixCtx<W>) -> Option<ElementId> {
         (self.build_fn)(ctx)
     }
 }

--- a/examples/vello_winit_examples/examples/hello_world.rs
+++ b/examples/vello_winit_examples/examples/hello_world.rs
@@ -79,7 +79,7 @@ impl FynixDemo for HelloWorld {
                 // changes (see `DemoWorld::update`).
                 v.add(ctx.reactive(
                     |w| w.fps_changed,
-                    |mut ctx| {
+                    |ctx| {
                         let fps = ctx.world.fps;
                         Some(
                             ctx.add_with::<Label>(|label, _| {


### PR DESCRIPTION
Avoids constructing a temporary `FynixCtx` for the initial build in `FynixCtx::reactive`; the existing context is passed directly. Rebuild calls in `Fynix::rebuild_reactives` still construct a scoped context, but now borrow it mutably rather than consuming it.