### PR TITLE
Back `ElementMetas` with a `TypeTable`, split into 3 columns

### DIFF
--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -160,10 +160,10 @@ impl<W> FynixCtx<'_, '_, W> {
         self.fynix.styles.clear_builder();
 
         if let Some(child_id) = child
-            && let Some(meta) =
-                self.fynix.elements.metas.get_mut(&child_id)
+            && let Some(node) =
+                self.fynix.elements.metas.node_mut(&child_id)
         {
-            meta.node.parent_id = Some(element_id);
+            node.parent_id = Some(element_id);
         }
         if let Some(elem) = self
             .fynix
@@ -185,7 +185,7 @@ impl<W> FynixCtx<'_, '_, W> {
     /// The first style committed inside `scope` becomes the element's
     /// [`primary_style`].
     ///
-    /// [`primary_style`]: crate::element::meta::ElementMeta::primary_style
+    /// [`primary_style`]: crate::element::meta::ElementMetas::primary_style
     #[must_use]
     fn style_scoped<T>(
         &mut self,
@@ -492,12 +492,7 @@ mod tests {
         assert_eq!(len, 5);
 
         let has_primary_style = |e: &ElementId| {
-            fynix
-                .elements
-                .metas
-                .get(e)
-                .and_then(|m| m.primary_style)
-                .is_some()
+            fynix.elements.metas.primary_style(e).is_some()
         };
 
         assert!(
@@ -568,12 +563,7 @@ mod tests {
         assert_eq!(fynix.styles.styles.len(), 1);
 
         let has_primary_style = |e: &ElementId| {
-            fynix
-                .elements
-                .metas
-                .get(e)
-                .and_then(|m| m.primary_style)
-                .is_some()
+            fynix.elements.metas.primary_style(e).is_some()
         };
 
         assert!(!has_primary_style(&elem_a));

--- a/crates/fynix/src/element.rs
+++ b/crates/fynix/src/element.rs
@@ -8,7 +8,7 @@ use crate::init::Init;
 pub mod layout;
 pub mod meta;
 pub mod storage;
-pub mod type_meta;
+mod type_meta;
 
 pub use fynix_macros::Element;
 pub use storage::{ElementId, Elements};

--- a/crates/fynix/src/element.rs
+++ b/crates/fynix/src/element.rs
@@ -8,6 +8,7 @@ use crate::init::Init;
 pub mod layout;
 pub mod meta;
 pub mod storage;
+pub mod type_meta;
 
 pub use fynix_macros::Element;
 pub use storage::{ElementId, Elements};

--- a/crates/fynix/src/element/layout.rs
+++ b/crates/fynix/src/element/layout.rs
@@ -2,7 +2,8 @@ use imaging::record::Scene;
 use rectree::{Constraint, RectNode, RectNodes, Rectree, Size};
 
 use crate::element::ElementId;
-use crate::element::meta::{ElementMetas, ElementTypeMetas};
+use crate::element::meta::ElementMetas;
+use crate::element::type_meta::ElementTypeMetas;
 use crate::resource::Resources;
 use crate::typing::type_pool::TypePool;
 
@@ -80,17 +81,8 @@ impl ElementNodes<'_> {
         self.resources.get_mut()
     }
 
-    pub fn cache_scene(
-        &mut self,
-        id: &ElementId,
-        scene: Scene,
-    ) -> bool {
-        if let Some(meta) = self.metas.get_mut(id) {
-            meta.cached_scene = Some(scene);
-            return true;
-        }
-
-        false
+    pub fn cache_scene(&mut self, id: &ElementId, scene: Scene) {
+        self.metas.set_scene(id, scene);
     }
 }
 
@@ -103,13 +95,13 @@ impl RectNodes for ElementNodes<'_> {
         &self,
         id: &ElementId,
     ) -> Option<&RectNode<ElementId>> {
-        self.metas.get(id).map(|m| &m.node)
+        self.metas.node(id)
     }
 
     fn get_node_mut(
         &mut self,
         id: &ElementId,
     ) -> Option<&mut RectNode<ElementId>> {
-        self.metas.get_mut(id).map(|m| &mut m.node)
+        self.metas.node_mut(id)
     }
 }

--- a/crates/fynix/src/element/meta.rs
+++ b/crates/fynix/src/element/meta.rs
@@ -1,74 +1,95 @@
-use alloc::vec::Vec;
-
-use hashbrown::HashMap;
 use imaging::record::Scene;
 use rectree::RectNode;
 
-use crate::element::{Element, ElementId};
+use crate::element::ElementId;
 use crate::style::StyleId;
 use crate::typing::ColumnId;
-use crate::typing::type_pool::TypePool;
-
-/// Per-element metadata.
-pub struct ElementMeta {
-    pub node: RectNode<ElementId>,
-    pub cached_scene: Option<Scene>,
-    /// When this element is removed, this style and all its
-    /// descendants in the style tree are also removed.
-    pub primary_style: Option<StyleId>,
-}
+use crate::typing::type_table::TypeTable;
 
 /// Per-element metadata storage, keyed by [`ElementId`].
+///
+/// Each metadata field lives in its own [`TypeTable`] column
+/// (struct-of-arrays). The layout node is dense, one per element,
+/// while the cached scene and primary style are sparse, present only
+/// when set.
+///
+/// The three columns are created up front and their [`ColumnId`]s
+/// cached, so every accessor reaches its column by index and skips
+/// the per-call [`TypeId`](core::any::TypeId) hash lookup.
 pub struct ElementMetas {
-    map: HashMap<ElementId, ElementMeta>,
+    table: TypeTable<ElementId>,
+    node_col: ColumnId,
+    scene_col: ColumnId,
+    style_col: ColumnId,
 }
 
 impl ElementMetas {
     pub fn new() -> Self {
+        let mut table = TypeTable::new();
+        let node_col = table.ensure_column::<RectNode<ElementId>>();
+        let scene_col = table.ensure_column::<Scene>();
+        let style_col = table.ensure_column::<StyleId>();
         Self {
-            map: HashMap::new(),
+            table,
+            node_col,
+            scene_col,
+            style_col,
         }
     }
 
+    /// Seeds the layout node for `id` and records its
+    /// `primary_style` when one is given.
     pub(super) fn init_element(
         &mut self,
         id: ElementId,
         primary_style: Option<StyleId>,
     ) {
-        self.map.insert(
-            id,
-            ElementMeta {
-                node: RectNode::new(None),
-                cached_scene: None,
-                primary_style,
-            },
-        );
+        self.table.insert(id, RectNode::<ElementId>::new(None));
+        if let Some(style) = primary_style {
+            self.table.insert(id, style);
+        }
     }
 
-    /// Removes the element meta and returns it for cleanup.
-    pub(super) fn remove(
-        &mut self,
-        id: &ElementId,
-    ) -> Option<ElementMeta> {
-        self.map.remove(id)
+    /// Drops every metadata column for `id`. Returns `true` if any
+    /// column held it.
+    pub(super) fn remove(&mut self, id: &ElementId) -> bool {
+        self.table.remove_row(id)
     }
 
-    pub fn get(&self, id: &ElementId) -> Option<&ElementMeta> {
-        self.map.get(id)
-    }
-
-    pub fn get_mut(
-        &mut self,
-        id: &ElementId,
-    ) -> Option<&mut ElementMeta> {
-        self.map.get_mut(id)
-    }
-
-    /// Iterates every element id and its metadata.
-    pub fn iter(
+    /// Returns the layout node for `id`, if present.
+    pub fn node(
         &self,
-    ) -> impl Iterator<Item = (&ElementId, &ElementMeta)> {
-        self.map.iter()
+        id: &ElementId,
+    ) -> Option<&RectNode<ElementId>> {
+        self.table.get_by_column(self.node_col, id)
+    }
+
+    /// Returns a mutable reference to the layout node for `id`.
+    pub fn node_mut(
+        &mut self,
+        id: &ElementId,
+    ) -> Option<&mut RectNode<ElementId>> {
+        self.table.get_mut_by_column(self.node_col, id)
+    }
+
+    /// Returns the cached scene for `id`, if one has been stored.
+    pub fn scene(&self, id: &ElementId) -> Option<&Scene> {
+        self.table.get_by_column(self.scene_col, id)
+    }
+
+    /// Caches `scene` for `id`.
+    pub fn set_scene(&mut self, id: &ElementId, scene: Scene) {
+        self.table.insert(*id, scene);
+    }
+
+    /// Returns the `primary_style` recorded for `id`, if any.
+    ///
+    /// When this element is removed, that style and all its
+    /// descendants in the style tree are also removed.
+    pub fn primary_style(&self, id: &ElementId) -> Option<StyleId> {
+        self.table
+            .get_by_column::<StyleId>(self.style_col, id)
+            .copied()
     }
 }
 
@@ -78,153 +99,69 @@ impl Default for ElementMetas {
     }
 }
 
-/// Per-type dispatch table registry, column-indexed.
-pub struct ElementTypeMetas {
-    columns: Vec<Option<ElementTypeMeta>>,
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::element::ElementId;
+    use crate::style::StyleIdGenerator;
+    use crate::typing::type_pool::TypePool;
 
-impl ElementTypeMetas {
-    pub fn new() -> Self {
-        Self {
-            columns: Vec::new(),
-        }
+    /// Mints two distinct element ids via a throwaway pool.
+    fn two_ids() -> (ElementId, ElementId) {
+        let mut pool = TypePool::new();
+        (ElementId(pool.insert(0u8)), ElementId(pool.insert(1u8)))
     }
 
-    /// Registers `E` at `col` if it has not been registered yet.
-    ///
-    /// `col` must have been obtained from
-    /// [`TypePool::ensure_column::<E>`].
-    pub fn register<E: Element>(&mut self, col: ColumnId) {
-        let i = col.index();
-        if self.columns.len() <= i {
-            self.columns.resize_with(i + 1, || None);
-        }
-        if self.columns[i].is_none() {
-            self.columns[i] = Some(ElementTypeMeta::new::<E>());
-        }
+    #[test]
+    fn init_seeds_node_and_primary_style() {
+        let (id, _) = two_ids();
+        let style = StyleIdGenerator::new().new_id();
+        let mut metas = ElementMetas::new();
+        metas.init_element(id, Some(style));
+
+        assert!(metas.node(&id).is_some());
+        assert_eq!(metas.primary_style(&id), Some(style));
+        // No scene is cached until one is set.
+        assert!(metas.scene(&id).is_none());
     }
 
-    /// Returns the [`ElementTypeMeta`] for `col`, or `None` if that
-    /// column has not been registered.
-    pub fn get_column(
-        &self,
-        col: ColumnId,
-    ) -> Option<&ElementTypeMeta> {
-        self.columns.get(col.index())?.as_ref()
-    }
-}
+    #[test]
+    fn init_without_primary_style_leaves_it_absent() {
+        let (id, _) = two_ids();
+        let mut metas = ElementMetas::new();
+        metas.init_element(id, None);
 
-impl Default for ElementTypeMetas {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-/// Monomorphized function pointers for a single element type.
-///
-/// Registered once per type via [`ElementTypeMetas::register`].
-pub struct ElementTypeMeta {
-    /// Returns `&dyn Element` from the pool without knowing the
-    /// concrete type at the call site.
-    pub get_dyn_fn: GetDynElementFn,
-    /// Visits each child of an element by calling `f` for every
-    /// [`ElementId`] the element yields from
-    /// [`super::ElementChildren::children`].
-    pub for_each_child_fn: ForEachChildFn,
-    /// Like [`ForEachChildFn`], but provides `&mut TypePool` to the
-    /// callback via [`TypePool::scope`].
-    pub for_each_child_mut_fn: ForEachChildMutFn,
-}
-
-impl ElementTypeMeta {
-    pub fn new<E: Element>() -> Self {
-        Self {
-            get_dyn_fn: get_dyn_element::<E>,
-            for_each_child_fn: for_each_child::<E>,
-            for_each_child_mut_fn: for_each_child_mut::<E>,
-        }
+        assert!(metas.node(&id).is_some());
+        assert_eq!(metas.primary_style(&id), None);
     }
 
-    pub fn get_dyn<'a>(
-        &self,
-        pool: &'a TypePool,
-        id: &ElementId,
-    ) -> Option<&'a dyn Element> {
-        (self.get_dyn_fn)(pool, id)
+    #[test]
+    fn set_scene_round_trips() {
+        let (id, _) = two_ids();
+        let mut metas = ElementMetas::new();
+        metas.init_element(id, None);
+
+        assert!(metas.scene(&id).is_none());
+        metas.set_scene(&id, Scene::new());
+        assert_eq!(metas.scene(&id), Some(&Scene::new()));
     }
 
-    pub fn for_each_child(
-        &self,
-        pool: &TypePool,
-        id: &ElementId,
-        f: &mut dyn FnMut(&ElementId),
-    ) {
-        (self.for_each_child_fn)(pool, id, f);
+    #[test]
+    fn remove_drops_every_column() {
+        let (id, other) = two_ids();
+        let style = StyleIdGenerator::new().new_id();
+        let mut metas = ElementMetas::new();
+        metas.init_element(id, Some(style));
+        metas.init_element(other, None);
+        metas.set_scene(&id, Scene::new());
+
+        assert!(metas.remove(&id));
+        assert!(metas.node(&id).is_none());
+        assert!(metas.scene(&id).is_none());
+        assert_eq!(metas.primary_style(&id), None);
+        // A second removal finds nothing left.
+        assert!(!metas.remove(&id));
+        // Sibling metadata is untouched.
+        assert!(metas.node(&other).is_some());
     }
-
-    pub fn for_each_child_mut(
-        &self,
-        pool: &mut TypePool,
-        id: &ElementId,
-        f: &mut dyn FnMut(&ElementId, &mut TypePool),
-    ) {
-        (self.for_each_child_mut_fn)(pool, id, f);
-    }
-}
-
-/// See [`ElementTypeMeta::get_dyn_fn`].
-pub type GetDynElementFn = for<'a> fn(
-    pool: &'a TypePool,
-    id: &ElementId,
-) -> Option<&'a dyn Element>;
-
-/// See [`ElementTypeMeta::for_each_child_fn`].
-pub type ForEachChildFn = fn(
-    pool: &TypePool,
-    id: &ElementId,
-    f: &mut dyn FnMut(&ElementId),
-);
-
-/// See [`ElementTypeMeta::for_each_child_mut_fn`].
-pub type ForEachChildMutFn = fn(
-    pool: &mut TypePool,
-    id: &ElementId,
-    f: &mut dyn FnMut(&ElementId, &mut TypePool),
-);
-
-/// See [`ElementTypeMeta::get_dyn_fn`].
-#[inline]
-pub fn get_dyn_element<'a, E: Element>(
-    pool: &'a TypePool,
-    id: &ElementId,
-) -> Option<&'a dyn Element> {
-    pool.get::<E>(id).map(|e| e as &dyn Element)
-}
-
-/// See [`ElementTypeMeta::for_each_child_fn`].
-#[inline]
-pub fn for_each_child<E: Element>(
-    pool: &TypePool,
-    id: &ElementId,
-    f: &mut dyn FnMut(&ElementId),
-) {
-    if let Some(element) = pool.get::<E>(id) {
-        for child in element.children() {
-            f(child);
-        }
-    }
-}
-
-/// See [`ElementTypeMeta::for_each_child_mut_fn`].
-#[inline]
-pub fn for_each_child_mut<E: Element>(
-    pool: &mut TypePool,
-    id: &ElementId,
-    f: &mut dyn FnMut(&ElementId, &mut TypePool),
-) {
-    pool.scope::<E, _>(id, |element, pool| {
-        for child in element.children() {
-            f(child, pool);
-        }
-    });
 }

--- a/crates/fynix/src/element/storage.rs
+++ b/crates/fynix/src/element/storage.rs
@@ -155,9 +155,8 @@ impl Elements {
             elements: &mut TypePool,
             on_removed: &mut impl FnMut(&ElementId, Option<StyleId>),
         ) -> bool {
-            if metas.node(id).is_some()
-                && let Some(type_meta) =
-                    type_metas.get_column(id.col_id())
+            if let Some(type_meta) =
+                type_metas.get_column(id.col_id())
             {
                 on_removed(id, metas.primary_style(id));
 

--- a/crates/fynix/src/element/storage.rs
+++ b/crates/fynix/src/element/storage.rs
@@ -5,7 +5,8 @@ use imaging::PaintSink;
 
 use super::Element;
 use super::layout::{ElementNodes, ElementTree};
-use super::meta::{ElementMeta, ElementMetas, ElementTypeMetas};
+use super::meta::ElementMetas;
+use crate::element::type_meta::ElementTypeMetas;
 use crate::resource::Resources;
 use crate::style::StyleId;
 use crate::typing::type_pool::{PoolKey, TypePool};
@@ -42,9 +43,9 @@ impl Elements {
     /// subtree.
     pub fn mark_dirty(&mut self, id: ElementId) {
         if self.dirty_elements.insert(id)
-            && let Some(meta) = self.metas.get_mut(&id)
+            && let Some(node) = self.metas.node_mut(&id)
         {
-            meta.node.state.reset();
+            node.state.reset();
         }
     }
 
@@ -84,8 +85,8 @@ impl Elements {
 
             // Set parent id on each child's meta node.
             for child_id in element.children() {
-                if let Some(meta) = self.metas.get_mut(child_id) {
-                    meta.node.parent_id = Some(id);
+                if let Some(node) = self.metas.node_mut(child_id) {
+                    node.parent_id = Some(id);
                 }
             }
             self.metas.init_element(id, primary_style);
@@ -137,27 +138,28 @@ impl Elements {
     /// Recursively removes the element subtree.
     ///
     /// `on_removed` runs for each removed element, in
-    /// parent-before-child order, with its id and meta. Use it to
-    /// clean up per-element resources such as styles and scopes.
+    /// parent-before-child order, with its id and `primary_style`.
+    /// Use it to clean up per-element resources such as styles and
+    /// scopes.
     ///
     /// Returns `true` if the element was present and removed.
     pub fn remove(
         &mut self,
         id: &ElementId,
-        mut on_removed: impl FnMut(&ElementId, &ElementMeta),
+        mut on_removed: impl FnMut(&ElementId, Option<StyleId>),
     ) -> bool {
         fn remove_recursive(
             id: &ElementId,
             metas: &mut ElementMetas,
             type_metas: &ElementTypeMetas,
             elements: &mut TypePool,
-            on_removed: &mut impl FnMut(&ElementId, &ElementMeta),
+            on_removed: &mut impl FnMut(&ElementId, Option<StyleId>),
         ) -> bool {
-            if let Some(meta) = metas.remove(id)
+            if metas.node(id).is_some()
                 && let Some(type_meta) =
                     type_metas.get_column(id.col_id())
             {
-                on_removed(id, &meta);
+                on_removed(id, metas.primary_style(id));
 
                 type_meta.for_each_child_mut(
                     elements,
@@ -170,6 +172,7 @@ impl Elements {
                     },
                 );
 
+                metas.remove(id);
                 elements.dyn_remove(id);
                 return true;
             }
@@ -180,7 +183,7 @@ impl Elements {
         // Mark the parent as dirty before dropped the child so we can
         // re-layout the parent's subtree once the child is gone.
         let parent_id =
-            self.metas.get(id).and_then(|meta| meta.node.parent_id);
+            self.metas.node(id).and_then(|node| node.parent_id);
 
         let removed = remove_recursive(
             id,
@@ -209,9 +212,9 @@ impl Elements {
         id: &ElementId,
         painter: &mut impl PaintSink,
     ) {
-        let Some(meta) = self.metas.get(id) else {
+        if self.metas.node(id).is_none() {
             return;
-        };
+        }
         if let Some(type_meta) =
             self.type_metas.get_column(id.col_id())
         {
@@ -226,7 +229,6 @@ impl Elements {
                 &mut |child| self.render(child, painter),
             );
         }
-        let _ = meta;
     }
 
     /// Lays out the subtree of every dirty element, draining the

--- a/crates/fynix/src/element/type_meta.rs
+++ b/crates/fynix/src/element/type_meta.rs
@@ -1,0 +1,156 @@
+use alloc::vec::Vec;
+
+use crate::element::{Element, ElementId};
+use crate::typing::ColumnId;
+use crate::typing::type_pool::TypePool;
+
+/// Per-type dispatch table registry, column-indexed.
+pub struct ElementTypeMetas {
+    columns: Vec<Option<ElementTypeMeta>>,
+}
+
+impl ElementTypeMetas {
+    pub fn new() -> Self {
+        Self {
+            columns: Vec::new(),
+        }
+    }
+
+    /// Registers `E` at `col` if it has not been registered yet.
+    ///
+    /// `col` must have been obtained from
+    /// [`TypePool::ensure_column::<E>`].
+    pub fn register<E: Element>(&mut self, col: ColumnId) {
+        let i = col.index();
+        if self.columns.len() <= i {
+            self.columns.resize_with(i + 1, || None);
+        }
+        if self.columns[i].is_none() {
+            self.columns[i] = Some(ElementTypeMeta::new::<E>());
+        }
+    }
+
+    /// Returns the [`ElementTypeMeta`] for `col`, or `None` if that
+    /// column has not been registered.
+    pub fn get_column(
+        &self,
+        col: ColumnId,
+    ) -> Option<&ElementTypeMeta> {
+        self.columns.get(col.index())?.as_ref()
+    }
+}
+
+impl Default for ElementTypeMetas {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Monomorphized function pointers for a single element type.
+///
+/// Registered once per type via [`ElementTypeMetas::register`].
+pub struct ElementTypeMeta {
+    /// Returns `&dyn Element` from the pool without knowing the
+    /// concrete type at the call site.
+    pub get_dyn_fn: GetDynElementFn,
+    /// Visits each child of an element by calling `f` for every
+    /// [`ElementId`] the element yields from
+    /// [`super::ElementChildren::children`].
+    pub for_each_child_fn: ForEachChildFn,
+    /// Like [`ForEachChildFn`], but provides `&mut TypePool` to the
+    /// callback via [`TypePool::scope`].
+    pub for_each_child_mut_fn: ForEachChildMutFn,
+}
+
+impl ElementTypeMeta {
+    pub fn new<E: Element>() -> Self {
+        Self {
+            get_dyn_fn: get_dyn_element::<E>,
+            for_each_child_fn: for_each_child::<E>,
+            for_each_child_mut_fn: for_each_child_mut::<E>,
+        }
+    }
+
+    pub fn get_dyn<'a>(
+        &self,
+        pool: &'a TypePool,
+        id: &ElementId,
+    ) -> Option<&'a dyn Element> {
+        (self.get_dyn_fn)(pool, id)
+    }
+
+    pub fn for_each_child(
+        &self,
+        pool: &TypePool,
+        id: &ElementId,
+        f: &mut dyn FnMut(&ElementId),
+    ) {
+        (self.for_each_child_fn)(pool, id, f);
+    }
+
+    pub fn for_each_child_mut(
+        &self,
+        pool: &mut TypePool,
+        id: &ElementId,
+        f: &mut dyn FnMut(&ElementId, &mut TypePool),
+    ) {
+        (self.for_each_child_mut_fn)(pool, id, f);
+    }
+}
+
+/// See [`ElementTypeMeta::get_dyn_fn`].
+pub type GetDynElementFn = for<'a> fn(
+    pool: &'a TypePool,
+    id: &ElementId,
+) -> Option<&'a dyn Element>;
+
+/// See [`ElementTypeMeta::for_each_child_fn`].
+pub type ForEachChildFn = fn(
+    pool: &TypePool,
+    id: &ElementId,
+    f: &mut dyn FnMut(&ElementId),
+);
+
+/// See [`ElementTypeMeta::for_each_child_mut_fn`].
+pub type ForEachChildMutFn = fn(
+    pool: &mut TypePool,
+    id: &ElementId,
+    f: &mut dyn FnMut(&ElementId, &mut TypePool),
+);
+
+/// See [`ElementTypeMeta::get_dyn_fn`].
+#[inline]
+pub fn get_dyn_element<'a, E: Element>(
+    pool: &'a TypePool,
+    id: &ElementId,
+) -> Option<&'a dyn Element> {
+    pool.get::<E>(id).map(|e| e as &dyn Element)
+}
+
+/// See [`ElementTypeMeta::for_each_child_fn`].
+#[inline]
+pub fn for_each_child<E: Element>(
+    pool: &TypePool,
+    id: &ElementId,
+    f: &mut dyn FnMut(&ElementId),
+) {
+    if let Some(element) = pool.get::<E>(id) {
+        for child in element.children() {
+            f(child);
+        }
+    }
+}
+
+/// See [`ElementTypeMeta::for_each_child_mut_fn`].
+#[inline]
+pub fn for_each_child_mut<E: Element>(
+    pool: &mut TypePool,
+    id: &ElementId,
+    f: &mut dyn FnMut(&ElementId, &mut TypePool),
+) {
+    pool.scope::<E, _>(id, |element, pool| {
+        for child in element.children() {
+            f(child, pool);
+        }
+    });
+}

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -121,9 +121,9 @@ impl Fynix {
         // styles are left for that subtree removal to handle.
         let mut has_removed_styles = false;
 
-        self.elements.remove(id, |id, meta| {
+        self.elements.remove(id, |id, primary_style| {
             if !has_removed_styles
-                && let Some(primary_style) = meta.primary_style
+                && let Some(primary_style) = primary_style
             {
                 has_removed_styles =
                     self.styles.remove(&primary_style);
@@ -169,10 +169,10 @@ impl Fynix {
             self.styles.clear_builder();
 
             if let Some(child_id) = child
-                && let Some(meta) =
-                    self.elements.metas.get_mut(&child_id)
+                && let Some(node) =
+                    self.elements.metas.node_mut(&child_id)
             {
-                meta.node.parent_id = Some(element_id);
+                node.parent_id = Some(element_id);
             }
             if let Some(elem) = self
                 .elements

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -241,9 +241,9 @@ impl ElementBuild for Button {
         painter: &mut dyn PaintSink,
         metas: &ElementMetas,
     ) {
-        let Some(meta) = metas.get(id) else { return };
-        let pos = meta.node.world_translation;
-        let size = meta.node.size;
+        let Some(node) = metas.node(id) else { return };
+        let pos = node.world_translation;
+        let size = node.size;
         let shape = kurbo::RoundedRect::new(
             pos.x as f64,
             pos.y as f64,
@@ -361,11 +361,11 @@ impl ElementBuild for Label {
         painter: &mut dyn PaintSink,
         metas: &ElementMetas,
     ) {
-        let Some(meta) = metas.get(id) else { return };
-        let Some(scene) = meta.cached_scene.as_ref() else {
+        let Some(node) = metas.node(id) else { return };
+        let Some(scene) = metas.scene(id) else {
             return;
         };
-        let pos = meta.node.world_translation;
+        let pos = node.world_translation;
         let transform =
             Affine::translate((pos.x as f64, pos.y as f64));
         replay_transformed(scene, painter, transform);


### PR DESCRIPTION
Replace the `HashMap<ElementId, ElementMeta>` behind `ElementMetas` with a `TypeTable<ElementId>` holding one column per field (struct-of-arrays): `RectNode<ElementId>`, `Scene`, and `StyleId`. The node column is dense, while cached scene and primary style are sparse, present only when set, dropping the two `Option`s.

The three column ids are resolved once at construction and cached, so each accessor reaches its column by index and skips the per-call `TypeId` hash lookup.

Element instances stay in `TypePool` so `ElementTypeMetas` remains compact and `id.col_id()` dispatch is unchanged; element and meta storage remain separate fields, so `layout` borrows them without aliasing.

`ElementMeta` is gone; `remove`'s `on_removed` now passes `Option<StyleId>`. Also moves the per-type dispatch machinery out of `meta.rs` into `type_meta.rs`.