### PR TITLE
Rename `ElementMetas` to `ElementTable`

### DIFF
--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -161,7 +161,7 @@ impl<W> FynixCtx<'_, '_, W> {
 
         if let Some(child_id) = child
             && let Some(node) =
-                self.fynix.elements.metas.node_mut(&child_id)
+                self.fynix.elements.table.node_mut(&child_id)
         {
             node.parent_id = Some(element_id);
         }
@@ -185,7 +185,7 @@ impl<W> FynixCtx<'_, '_, W> {
     /// The first style committed inside `scope` becomes the element's
     /// [`primary_style`].
     ///
-    /// [`primary_style`]: crate::element::meta::ElementMetas::primary_style
+    /// [`primary_style`]: crate::element::table::ElementTable::primary_style
     #[must_use]
     fn style_scoped<T>(
         &mut self,
@@ -492,7 +492,7 @@ mod tests {
         assert_eq!(len, 5);
 
         let has_primary_style = |e: &ElementId| {
-            fynix.elements.metas.primary_style(e).is_some()
+            fynix.elements.table.primary_style(e).is_some()
         };
 
         assert!(
@@ -563,7 +563,7 @@ mod tests {
         assert_eq!(fynix.styles.styles.len(), 1);
 
         let has_primary_style = |e: &ElementId| {
-            fynix.elements.metas.primary_style(e).is_some()
+            fynix.elements.table.primary_style(e).is_some()
         };
 
         assert!(!has_primary_style(&elem_a));

--- a/crates/fynix/src/element.rs
+++ b/crates/fynix/src/element.rs
@@ -6,8 +6,8 @@ use crate::element::table::ElementTable;
 use crate::init::Init;
 
 pub mod layout;
-pub mod table;
 pub mod storage;
+pub mod table;
 mod type_meta;
 
 pub use fynix_macros::Element;

--- a/crates/fynix/src/element.rs
+++ b/crates/fynix/src/element.rs
@@ -2,11 +2,11 @@ use imaging::PaintSink;
 use rectree::{Constraint, Size};
 
 use crate::element::layout::ElementNodes;
-use crate::element::meta::ElementMetas;
+use crate::element::table::ElementTable;
 use crate::init::Init;
 
 pub mod layout;
-pub mod meta;
+pub mod table;
 pub mod storage;
 mod type_meta;
 
@@ -83,7 +83,7 @@ pub trait ElementBuild {
         &self,
         id: &ElementId,
         painter: &mut dyn PaintSink,
-        metas: &ElementMetas,
+        table: &ElementTable,
     ) {
     }
 }

--- a/crates/fynix/src/element/layout.rs
+++ b/crates/fynix/src/element/layout.rs
@@ -2,7 +2,7 @@ use imaging::record::Scene;
 use rectree::{Constraint, RectNode, RectNodes, Rectree, Size};
 
 use crate::element::ElementId;
-use crate::element::meta::ElementMetas;
+use crate::element::table::ElementTable;
 use crate::element::type_meta::ElementTypeMetas;
 use crate::resource::Resources;
 use crate::typing::type_pool::TypePool;
@@ -68,7 +68,7 @@ impl<'a> Rectree for ElementTree<'a> {
 }
 
 pub struct ElementNodes<'a> {
-    pub(crate) metas: &'a mut ElementMetas,
+    pub(crate) table: &'a mut ElementTable,
     pub(crate) resources: &'a mut Resources,
 }
 
@@ -82,7 +82,7 @@ impl ElementNodes<'_> {
     }
 
     pub fn cache_scene(&mut self, id: &ElementId, scene: Scene) {
-        self.metas.set_scene(id, scene);
+        self.table.set_scene(id, scene);
     }
 }
 
@@ -95,13 +95,13 @@ impl RectNodes for ElementNodes<'_> {
         &self,
         id: &ElementId,
     ) -> Option<&RectNode<ElementId>> {
-        self.metas.node(id)
+        self.table.node(id)
     }
 
     fn get_node_mut(
         &mut self,
         id: &ElementId,
     ) -> Option<&mut RectNode<ElementId>> {
-        self.metas.node_mut(id)
+        self.table.node_mut(id)
     }
 }

--- a/crates/fynix/src/element/storage.rs
+++ b/crates/fynix/src/element/storage.rs
@@ -5,7 +5,7 @@ use imaging::PaintSink;
 
 use super::Element;
 use super::layout::{ElementNodes, ElementTree};
-use super::meta::ElementMetas;
+use super::table::ElementTable;
 use crate::element::type_meta::ElementTypeMetas;
 use crate::resource::Resources;
 use crate::style::StyleId;
@@ -19,7 +19,7 @@ pub struct Elements {
     // TODO(nixon): Make these private and provide a more
     // elegant API!
     pub elements: TypePool,
-    pub metas: ElementMetas,
+    pub table: ElementTable,
     pub type_metas: ElementTypeMetas,
     /// Elements whose subtree changed and needs re-layout/render,
     /// e.g. after a reactive scope rebuilt its child.
@@ -30,7 +30,7 @@ impl Elements {
     pub fn new() -> Self {
         Self {
             elements: TypePool::new(),
-            metas: ElementMetas::new(),
+            table: ElementTable::new(),
             type_metas: ElementTypeMetas::new(),
             dirty_elements: HashSet::new(),
         }
@@ -43,7 +43,7 @@ impl Elements {
     /// subtree.
     pub fn mark_dirty(&mut self, id: ElementId) {
         if self.dirty_elements.insert(id)
-            && let Some(node) = self.metas.node_mut(&id)
+            && let Some(node) = self.table.node_mut(&id)
         {
             node.state.reset();
         }
@@ -83,13 +83,13 @@ impl Elements {
             let id = ElementId(key);
             let element = create(id);
 
-            // Set parent id on each child's meta node.
+            // Set parent id on each child's table node.
             for child_id in element.children() {
-                if let Some(node) = self.metas.node_mut(child_id) {
+                if let Some(node) = self.table.node_mut(child_id) {
                     node.parent_id = Some(id);
                 }
             }
-            self.metas.init_element(id, primary_style);
+            self.table.init_element(id, primary_style);
             element
         });
 
@@ -150,7 +150,7 @@ impl Elements {
     ) -> bool {
         fn remove_recursive(
             id: &ElementId,
-            metas: &mut ElementMetas,
+            table: &mut ElementTable,
             type_metas: &ElementTypeMetas,
             elements: &mut TypePool,
             on_removed: &mut impl FnMut(&ElementId, Option<StyleId>),
@@ -158,20 +158,20 @@ impl Elements {
             if let Some(type_meta) =
                 type_metas.get_column(id.col_id())
             {
-                on_removed(id, metas.primary_style(id));
+                on_removed(id, table.primary_style(id));
 
                 type_meta.for_each_child_mut(
                     elements,
                     id,
                     &mut |child_id, elements| {
                         remove_recursive(
-                            child_id, metas, type_metas, elements,
+                            child_id, table, type_metas, elements,
                             on_removed,
                         );
                     },
                 );
 
-                metas.remove(id);
+                table.remove(id);
                 elements.dyn_remove(id);
                 return true;
             }
@@ -182,11 +182,11 @@ impl Elements {
         // Mark the parent as dirty before dropped the child so we can
         // re-layout the parent's subtree once the child is gone.
         let parent_id =
-            self.metas.node(id).and_then(|node| node.parent_id);
+            self.table.node(id).and_then(|node| node.parent_id);
 
         let removed = remove_recursive(
             id,
-            &mut self.metas,
+            &mut self.table,
             &self.type_metas,
             &mut self.elements,
             &mut on_removed,
@@ -211,7 +211,7 @@ impl Elements {
         id: &ElementId,
         painter: &mut impl PaintSink,
     ) {
-        if self.metas.node(id).is_none() {
+        if self.table.node(id).is_none() {
             return;
         }
         if let Some(type_meta) =
@@ -220,7 +220,7 @@ impl Elements {
             if let Some(element) =
                 type_meta.get_dyn(&self.elements, id)
             {
-                element.render(id, painter, &self.metas);
+                element.render(id, painter, &self.table);
             }
             type_meta.for_each_child(
                 &self.elements,
@@ -239,7 +239,7 @@ impl Elements {
         };
 
         let mut nodes = ElementNodes {
-            metas: &mut self.metas,
+            table: &mut self.table,
             resources,
         };
 

--- a/crates/fynix/src/element/table.rs
+++ b/crates/fynix/src/element/table.rs
@@ -16,14 +16,14 @@ use crate::typing::type_table::TypeTable;
 /// The three columns are created up front and their [`ColumnId`]s
 /// cached, so every accessor reaches its column by index and skips
 /// the per-call [`TypeId`](core::any::TypeId) hash lookup.
-pub struct ElementMetas {
+pub struct ElementTable {
     table: TypeTable<ElementId>,
     node_col: ColumnId,
     scene_col: ColumnId,
     style_col: ColumnId,
 }
 
-impl ElementMetas {
+impl ElementTable {
     pub fn new() -> Self {
         let mut table = TypeTable::new();
         let node_col = table.ensure_column::<RectNode<ElementId>>();
@@ -93,7 +93,7 @@ impl ElementMetas {
     }
 }
 
-impl Default for ElementMetas {
+impl Default for ElementTable {
     fn default() -> Self {
         Self::new()
     }
@@ -116,52 +116,52 @@ mod tests {
     fn init_seeds_node_and_primary_style() {
         let (id, _) = two_ids();
         let style = StyleIdGenerator::new().new_id();
-        let mut metas = ElementMetas::new();
-        metas.init_element(id, Some(style));
+        let mut table = ElementTable::new();
+        table.init_element(id, Some(style));
 
-        assert!(metas.node(&id).is_some());
-        assert_eq!(metas.primary_style(&id), Some(style));
+        assert!(table.node(&id).is_some());
+        assert_eq!(table.primary_style(&id), Some(style));
         // No scene is cached until one is set.
-        assert!(metas.scene(&id).is_none());
+        assert!(table.scene(&id).is_none());
     }
 
     #[test]
     fn init_without_primary_style_leaves_it_absent() {
         let (id, _) = two_ids();
-        let mut metas = ElementMetas::new();
-        metas.init_element(id, None);
+        let mut table = ElementTable::new();
+        table.init_element(id, None);
 
-        assert!(metas.node(&id).is_some());
-        assert_eq!(metas.primary_style(&id), None);
+        assert!(table.node(&id).is_some());
+        assert_eq!(table.primary_style(&id), None);
     }
 
     #[test]
     fn set_scene_round_trips() {
         let (id, _) = two_ids();
-        let mut metas = ElementMetas::new();
-        metas.init_element(id, None);
+        let mut table = ElementTable::new();
+        table.init_element(id, None);
 
-        assert!(metas.scene(&id).is_none());
-        metas.set_scene(&id, Scene::new());
-        assert_eq!(metas.scene(&id), Some(&Scene::new()));
+        assert!(table.scene(&id).is_none());
+        table.set_scene(&id, Scene::new());
+        assert_eq!(table.scene(&id), Some(&Scene::new()));
     }
 
     #[test]
     fn remove_drops_every_column() {
         let (id, other) = two_ids();
         let style = StyleIdGenerator::new().new_id();
-        let mut metas = ElementMetas::new();
-        metas.init_element(id, Some(style));
-        metas.init_element(other, None);
-        metas.set_scene(&id, Scene::new());
+        let mut table = ElementTable::new();
+        table.init_element(id, Some(style));
+        table.init_element(other, None);
+        table.set_scene(&id, Scene::new());
 
-        assert!(metas.remove(&id));
-        assert!(metas.node(&id).is_none());
-        assert!(metas.scene(&id).is_none());
-        assert_eq!(metas.primary_style(&id), None);
+        assert!(table.remove(&id));
+        assert!(table.node(&id).is_none());
+        assert!(table.scene(&id).is_none());
+        assert_eq!(table.primary_style(&id), None);
         // A second removal finds nothing left.
-        assert!(!metas.remove(&id));
+        assert!(!table.remove(&id));
         // Sibling metadata is untouched.
-        assert!(metas.node(&other).is_some());
+        assert!(table.node(&other).is_some());
     }
 }

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -170,7 +170,7 @@ impl Fynix {
 
             if let Some(child_id) = child
                 && let Some(node) =
-                    self.elements.metas.node_mut(&child_id)
+                    self.elements.table.node_mut(&child_id)
             {
                 node.parent_id = Some(element_id);
             }

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -6,7 +6,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use fynix::element::layout::ElementNodes;
-use fynix::element::meta::ElementMetas;
+use fynix::element::table::ElementTable;
 use fynix::imaging::kurbo::{Affine, Stroke};
 use fynix::imaging::peniko::{Brush, BrushRef, Color, Fill, Style};
 use fynix::imaging::record::{Glyph, Scene, replay_transformed};
@@ -239,9 +239,9 @@ impl ElementBuild for Button {
         &self,
         id: &ElementId,
         painter: &mut dyn PaintSink,
-        metas: &ElementMetas,
+        table: &ElementTable,
     ) {
-        let Some(node) = metas.node(id) else { return };
+        let Some(node) = table.node(id) else { return };
         let pos = node.world_translation;
         let size = node.size;
         let shape = kurbo::RoundedRect::new(
@@ -359,10 +359,10 @@ impl ElementBuild for Label {
         &self,
         id: &ElementId,
         painter: &mut dyn PaintSink,
-        metas: &ElementMetas,
+        table: &ElementTable,
     ) {
-        let Some(node) = metas.node(id) else { return };
-        let Some(scene) = metas.scene(id) else {
+        let Some(node) = table.node(id) else { return };
+        let Some(scene) = table.scene(id) else {
             return;
         };
         let pos = node.world_translation;


### PR DESCRIPTION
Rename the `ElementMetas` type to `ElementTable`, the `metas` field and local variables to `table`, and move `element/meta.rs` to `element/table.rs`.