### PR TITLE
Add `fynix_hit_test` crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
-      - run: cargo check --workspace --no-default-features
+      - run: cargo check --workspace --no-default-features --features=libm
 
   clippy:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,6 +609,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fynix_hit_test"
+version = "0.1.0"
+dependencies = [
+ "fynix",
+ "hashbrown 0.16.1",
+ "spatree",
+]
+
+[[package]]
 name = "fynix_macros"
 version = "0.1.0"
 dependencies = [
@@ -1921,6 +1930,14 @@ name = "sparse_map"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea8f483b9159a7efadd9a82915dc40fdc9cfef7985651bbb83a8db20b12bf629"
+
+[[package]]
+name = "spatree"
+version = "0.1.0"
+source = "git+https://github.com/voxell-tech/spatree?rev=61a3dab#61a3dab5aec44abd087ddba8d81ee122f36d5b8c"
+dependencies = [
+ "kurbo",
+]
 
 [[package]]
 name = "spirv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/voxell-tech/fynix"
 
 [workspace.dependencies]
-fynix = { version = "0.1.0", path = "crates/fynix" }
+fynix = { version = "0.1.0", path = "crates/fynix", default-features = false }
 fynix_macros = { version = "0.1.0", path = "crates/fynix_macros" }
-fynix_elements = { version = "0.1.0", path = "crates/fynix_elements" }
-fynix_hit_test = { version = "0.1.0", path = "crates/fynix_hit_test" }
+fynix_elements = { version = "0.1.0", path = "crates/fynix_elements", default-features = false }
+fynix_hit_test = { version = "0.1.0", path = "crates/fynix_hit_test", default-features = false }
 typarena = { version = "0.1.0", path = "crates/typarena" }
 
 rectree = { git = "https://github.com/voxell-tech/rectree", rev = "e9729bf" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,11 @@ repository = "https://github.com/voxell-tech/fynix"
 fynix = { version = "0.1.0", path = "crates/fynix" }
 fynix_macros = { version = "0.1.0", path = "crates/fynix_macros" }
 fynix_elements = { version = "0.1.0", path = "crates/fynix_elements" }
+fynix_hit_test = { version = "0.1.0", path = "crates/fynix_hit_test" }
 typarena = { version = "0.1.0", path = "crates/typarena" }
 
 rectree = { git = "https://github.com/voxell-tech/rectree", rev = "e9729bf" }
+spatree = { git = "https://github.com/voxell-tech/spatree", rev = "61a3dab", default-features = false }
 field_path = "0.4.1"
 parley = { version = "0.7.0", default-features = false }
 imaging = { version = "0.0.1", default-features = false }

--- a/crates/fynix/src/element/layout.rs
+++ b/crates/fynix/src/element/layout.rs
@@ -91,17 +91,16 @@ impl ElementNodes<'_> {
 impl RectNodes for ElementNodes<'_> {
     type Id = ElementId;
 
-    fn get_node(
-        &self,
-        id: &ElementId,
-    ) -> Option<&RectNode<ElementId>> {
+    fn get_node(&self, id: &ElementId) -> Option<&ElementNode> {
         self.table.node(id)
     }
 
     fn get_node_mut(
         &mut self,
         id: &ElementId,
-    ) -> Option<&mut RectNode<ElementId>> {
+    ) -> Option<&mut ElementNode> {
         self.table.node_mut(id)
     }
 }
+
+pub(crate) type ElementNode = RectNode<ElementId>;

--- a/crates/fynix/src/element/storage.rs
+++ b/crates/fynix/src/element/storage.rs
@@ -5,7 +5,7 @@ use imaging::PaintSink;
 use typarena::type_pool::{PoolKey, TypePool};
 
 use super::Element;
-use super::layout::{ElementNodes, ElementTree};
+use super::layout::{ElementNode, ElementNodes, ElementTree};
 use super::table::ElementTable;
 use crate::element::type_meta::ElementTypeMetas;
 use crate::resource::Resources;
@@ -226,6 +226,45 @@ impl Elements {
                 &self.elements,
                 id,
                 &mut |child| self.render(child, painter),
+            );
+        }
+    }
+
+    /// Visits the subtree rooted at `id` in paint order, calling
+    /// `visit` with each element's id and layout node.
+    ///
+    /// Order matches [`Self::render`]: a parent is visited before its
+    /// children, so a later visit is an element painted on top. Used
+    /// to feed an external hit-test index each element's absolute
+    /// rect (via `node.world_translation` and `node.size`). Layout
+    /// must be complete for those values to be current.
+    pub fn visit_paint_order(
+        &self,
+        id: &ElementId,
+        mut visit: impl FnMut(&ElementId, &ElementNode),
+    ) {
+        self.visit_paint_order_inner(id, &mut visit);
+    }
+
+    fn visit_paint_order_inner(
+        &self,
+        id: &ElementId,
+        visit: &mut dyn FnMut(&ElementId, &ElementNode),
+    ) {
+        let Some(node) = self.table.node(id) else {
+            return;
+        };
+        visit(id, node);
+
+        if let Some(type_meta) =
+            self.type_metas.get_column(id.col_id())
+        {
+            type_meta.for_each_child(
+                &self.elements,
+                id,
+                &mut |child| {
+                    self.visit_paint_order_inner(child, visit);
+                },
             );
         }
     }

--- a/crates/fynix/src/element/table.rs
+++ b/crates/fynix/src/element/table.rs
@@ -1,9 +1,9 @@
 use imaging::record::Scene;
-use rectree::RectNode;
 use typarena::ColumnId;
 use typarena::type_table::TypeTable;
 
 use crate::element::ElementId;
+use crate::element::layout::ElementNode;
 use crate::style::StyleId;
 
 /// Per-element metadata storage, keyed by [`ElementId`].
@@ -26,7 +26,7 @@ pub struct ElementTable {
 impl ElementTable {
     pub fn new() -> Self {
         let mut table = TypeTable::new();
-        let node_col = table.ensure_column::<RectNode<ElementId>>();
+        let node_col = table.ensure_column::<ElementNode>();
         let scene_col = table.ensure_column::<Scene>();
         let style_col = table.ensure_column::<StyleId>();
         Self {
@@ -44,7 +44,7 @@ impl ElementTable {
         id: ElementId,
         primary_style: Option<StyleId>,
     ) {
-        self.table.insert(id, RectNode::<ElementId>::new(None));
+        self.table.insert(id, ElementNode::new(None));
         if let Some(style) = primary_style {
             self.table.insert(id, style);
         }
@@ -57,10 +57,7 @@ impl ElementTable {
     }
 
     /// Returns the layout node for `id`, if present.
-    pub fn node(
-        &self,
-        id: &ElementId,
-    ) -> Option<&RectNode<ElementId>> {
+    pub fn node(&self, id: &ElementId) -> Option<&ElementNode> {
         self.table.get_by_column(self.node_col, id)
     }
 
@@ -68,7 +65,7 @@ impl ElementTable {
     pub fn node_mut(
         &mut self,
         id: &ElementId,
-    ) -> Option<&mut RectNode<ElementId>> {
+    ) -> Option<&mut ElementNode> {
         self.table.get_mut_by_column(self.node_col, id)
     }
 

--- a/crates/fynix_hit_test/Cargo.toml
+++ b/crates/fynix_hit_test/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "fynix_hit_test"
+description = "Spatial hit-testing for fynix."
+keywords = ["ui", "gui", "hit-test", "spatial"]
+categories = ["gui"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+fynix.workspace = true
+hashbrown.workspace = true
+spatree.workspace = true
+
+[features]
+default = ["std"]
+std = ["fynix/std", "spatree/std"]
+libm = ["fynix/libm", "spatree/libm"]

--- a/crates/fynix_hit_test/src/lib.rs
+++ b/crates/fynix_hit_test/src/lib.rs
@@ -51,9 +51,9 @@ impl HitTest {
     /// Most of a scene is not interactive, so only elements that can
     /// receive a hit-tested interaction need to be in the spatree.
     /// The whole subtree is still walked to reach interactive
-    /// descendants, but non-indexed elements add nothing to the
-    /// tree. Paint order is preserved among indexed elements, so
-    /// the topmost still wins.
+    /// descendants, but non-indexed elements add nothing to the tree.
+    /// Paint order is preserved among indexed elements, so the
+    /// topmost still wins.
     ///
     /// Layout must be complete so each element's `world_translation`
     /// and `size` are current.

--- a/crates/fynix_hit_test/src/lib.rs
+++ b/crates/fynix_hit_test/src/lib.rs
@@ -1,0 +1,119 @@
+//! Spatial hit-testing for fynix.
+//!
+//! Resolves a pointer position to the element underneath it, using a
+//! spatial index built once after layout and queried per event.
+
+#![no_std]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use fynix::element::ElementId;
+use fynix::element::storage::Elements;
+use hashbrown::HashMap;
+use spatree::kurbo::{Point, Rect};
+use spatree::{RectId, Spatree};
+
+/// The element resolved under a pointer position, plus the position
+/// expressed relative to that element's origin.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Hit {
+    /// The topmost element whose absolute rect contains the point.
+    pub id: ElementId,
+    /// Pointer position relative to the hit element's origin.
+    pub local: Point,
+}
+
+/// A spatial index over an element subtree's absolute rects, used to
+/// resolve a pointer position to the element underneath it.
+///
+/// Built once from a laid-out tree via [`Self::build`], then queried
+/// per pointer event. Rects are pushed in paint order (parents before
+/// children), so a later push is an element painted on top;
+/// [`Self::query`] resolves overlaps in favour of that topmost
+/// element.
+pub struct HitTest {
+    tree: Spatree,
+    /// Push-order mapping from [`RectId`] to [`ElementId`], used by
+    /// [`Self::query`] to recover the element after the spatree
+    /// resolves a point.
+    ids: Vec<ElementId>,
+    /// Reverse mapping from `ElementId` to `RectId`, used by
+    /// [`Self::contains`] for O(1) bounds lookup.
+    id_map: HashMap<ElementId, RectId>,
+}
+
+impl HitTest {
+    /// Builds a hit-test index over the subtree rooted at `root`,
+    /// indexing only the elements `include` accepts.
+    ///
+    /// Most of a scene is not interactive, so only elements that can
+    /// receive a hit-tested interaction need to be in the spatree.
+    /// The whole subtree is still walked to reach interactive
+    /// descendants, but non-indexed elements add nothing to the
+    /// tree. Paint order is preserved among indexed elements, so
+    /// the topmost still wins.
+    ///
+    /// Layout must be complete so each element's `world_translation`
+    /// and `size` are current.
+    pub fn build(
+        elements: &Elements,
+        root: &ElementId,
+        include: impl Fn(&ElementId) -> bool,
+    ) -> Self {
+        let mut tree = Spatree::new();
+        let mut ids = Vec::new();
+        let mut id_map = HashMap::new();
+
+        elements.visit_paint_order(root, |id, node| {
+            if !include(id) {
+                return;
+            }
+
+            let origin = node.world_translation;
+            let size = node.size;
+
+            let x0 = origin.x as f64;
+            let y0 = origin.y as f64;
+            let x1 = x0 + size.width as f64;
+            let y1 = y0 + size.height as f64;
+            let rect_id = tree.push_rect(Rect::new(x0, y0, x1, y1));
+            ids.push(*id);
+            id_map.insert(*id, rect_id);
+        });
+
+        tree.build(|rect| rect.center());
+
+        Self { tree, ids, id_map }
+    }
+
+    /// Returns the topmost element whose absolute rect contains
+    /// `point`, or `None` if the point misses every element.
+    pub fn query(&self, point: Point) -> Option<Hit> {
+        let rect_id = self.tree.query_point_single(
+            point,
+            // Later push order paints on top, so the larger id wins.
+            #[inline(always)]
+            |a, b| if a > b { a } else { b },
+        )?;
+
+        let id = *self.ids.get(*rect_id)?;
+        let rect = self.tree.get_rect(rect_id)?;
+        Some(Hit {
+            id,
+            local: Point::new(point.x - rect.x0, point.y - rect.y0),
+        })
+    }
+
+    /// Returns `true` if `id`'s absolute rect contains `point`.
+    ///
+    /// Used as the bubbling gate: an ancestor handles a pointer
+    /// interaction only while the pointer is still within its bounds.
+    pub fn contains(&self, id: &ElementId, point: Point) -> bool {
+        self.id_map
+            .get(id)
+            .and_then(|id| self.tree.get_rect(*id))
+            .is_some_and(|rect| rect.contains(point))
+    }
+}


### PR DESCRIPTION
- Add `fynix_hit_test` crate.
- Add `Elements::visit_paint_order`, which walks a laid-out subtree in paint order and hands each element's id and layout node to a visitor, so an external index can record absolute rects.