### PR TITLE
Extract `Events` into `fynix_event` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,6 +592,7 @@ name = "fynix"
 version = "0.1.0"
 dependencies = [
  "field_path",
+ "fynix_event",
  "fynix_macros",
  "hashbrown 0.16.1",
  "imaging",
@@ -606,6 +607,13 @@ dependencies = [
  "field_path",
  "fynix",
  "parley",
+]
+
+[[package]]
+name = "fynix_event"
+version = "0.1.0"
+dependencies = [
+ "typarena",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/voxell-tech/fynix"
 
 [workspace.dependencies]
 fynix = { version = "0.1.0", path = "crates/fynix", default-features = false }
+fynix_event = { version = "0.1.0", path = "crates/fynix_event" }
 fynix_macros = { version = "0.1.0", path = "crates/fynix_macros" }
 fynix_elements = { version = "0.1.0", path = "crates/fynix_elements", default-features = false }
 fynix_hit_test = { version = "0.1.0", path = "crates/fynix_hit_test", default-features = false }

--- a/crates/fynix/Cargo.toml
+++ b/crates/fynix/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+fynix_event.workspace = true
 fynix_macros.workspace = true
 typarena.workspace = true
 rectree.workspace = true

--- a/crates/fynix/src/interaction.rs
+++ b/crates/fynix/src/interaction.rs
@@ -1,7 +1,7 @@
+use fynix_event::Events;
 use typarena::type_table::TypeTable;
 
 use crate::element::ElementId;
-use crate::events::Events;
 
 /// User-written interaction handler: reacts to interaction `I`,
 /// emitting messages into [`Events`].

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -4,12 +4,12 @@
 extern crate alloc;
 
 pub use field_path;
+use fynix_event::Events;
 pub use imaging;
 use imaging::PaintSink;
 
 use crate::ctx::FynixCtx;
 use crate::element::{ElementId, Elements};
-use crate::events::Events;
 use crate::interaction::Interactions;
 use crate::reactive::{ReactiveElement, Reactives};
 use crate::resource::Resources;
@@ -18,7 +18,6 @@ use crate::style::{StyleId, Styles};
 pub mod composer;
 pub mod ctx;
 pub mod element;
-pub mod events;
 pub mod init;
 pub mod interaction;
 pub mod reactive;
@@ -37,7 +36,6 @@ pub mod prelude {
     pub use crate::element::{
         Element, ElementBuild, ElementChildren, ElementId,
     };
-    pub use crate::events::Events;
     pub use crate::init::Init;
     pub use crate::style::{Stylable, path};
 }

--- a/crates/fynix_event/Cargo.toml
+++ b/crates/fynix_event/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "fynix_event"
+description = "Typed message queue for fynix."
+keywords = ["ui", "gui", "events", "no_std"]
+categories = ["gui", "no-std"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+typarena.workspace = true

--- a/crates/fynix_event/src/lib.rs
+++ b/crates/fynix_event/src/lib.rs
@@ -1,3 +1,12 @@
+//! Typed message queue for fynix.
+//!
+//! A small queue of typed messages flowing from the UI to the host
+//! world, for backends that do not provide their own event system.
+
+#![no_std]
+
+extern crate alloc;
+
 use typarena::type_pool::TypePool;
 
 /// Fynix-owned queue of typed messages flowing from the UI to the


### PR DESCRIPTION
Move the typed message queue out of fynix core into its own crate, so a backend that already has an event system need not pull it in.