### PR TITLE
Change `Fynix` to single world backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "imaging",
  "rectree",
+ "sparse_map",
  "typarena",
 ]
 

--- a/crates/fynix/Cargo.toml
+++ b/crates/fynix/Cargo.toml
@@ -14,6 +14,7 @@ fynix_event.workspace = true
 fynix_macros.workspace = true
 typarena.workspace = true
 rectree.workspace = true
+sparse_map.workspace = true
 hashbrown.workspace = true
 field_path.workspace = true
 imaging.workspace = true

--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -27,7 +27,7 @@ use crate::style::{Stylable, StyleId, StyleValue};
 ///
 /// [`Style`]: crate::style::Style
 pub struct FynixCtx<'f, 'w, W> {
-    fynix: &'f mut Fynix,
+    fynix: &'f mut Fynix<W>,
     pub world: &'w mut W,
 
     prev_style: Option<StyleId>,
@@ -37,7 +37,7 @@ pub struct FynixCtx<'f, 'w, W> {
 
 impl<W> FynixCtx<'_, '_, W> {
     pub(crate) fn new<'f, 'w>(
-        fynix: &'f mut Fynix,
+        fynix: &'f mut Fynix<W>,
         world: &'w mut W,
         prev_style: Option<StyleId>,
     ) -> FynixCtx<'f, 'w, W> {
@@ -134,10 +134,7 @@ impl<W> FynixCtx<'_, '_, W> {
         &mut self,
         changed: ChangedFn<W>,
         build: BuildFn<W>,
-    ) -> ElementHandle<'_>
-    where
-        W: 'static,
-    {
+    ) -> ElementHandle<'_> {
         self.commit_pending_styles();
 
         // Build the holder element and its reactive together: the

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -46,24 +46,22 @@ mod id;
 /// style state.
 ///
 /// Obtain a [`FynixCtx`] via [`Self::root_ctx`] to start building the
-/// UI.
-pub struct Fynix {
-    // TODO(nixon): Make these private and provide a more elegant
-    // API!
-    pub elements: Elements,
-    pub styles: Styles,
+/// user interface.
+pub struct Fynix<W> {
     pub resources: Resources,
-    pub reactives: Reactives,
-    pub events: Events,
-    pub interactions: Interactions,
+    elements: Elements,
+    styles: Styles,
+    reactives: Reactives<W>,
+    events: Events,
+    interactions: Interactions,
 }
 
-impl Fynix {
+impl<W> Fynix<W> {
     pub fn new() -> Self {
         Self {
+            resources: Resources::new(),
             elements: Elements::new(),
             styles: Styles::new(),
-            resources: Resources::new(),
             reactives: Reactives::new(),
             events: Events::new(),
             interactions: Interactions::new(),
@@ -74,7 +72,7 @@ impl Fynix {
     /// element type and the interaction type `I`, if one exists.
     ///
     /// Returns `true` if a handler ran. Messages the handler emits
-    /// land in [`Self::events`].
+    /// land in the event queue.
     #[inline]
     pub fn dispatch<I: 'static>(
         &mut self,
@@ -133,12 +131,12 @@ impl Fynix {
         })
     }
 
-    /// Re-runs every reactive of world type `W` whose `changed_fn`
-    /// reports a change, rebuilding its subtree in place.
+    /// Re-runs every reactive whose `changed_fn` reports a change,
+    /// rebuilding its subtree in place.
     ///
     /// Intended to be called by the backend once per frame.
-    pub fn update_reactives<W: 'static>(&mut self, world: &mut W) {
-        for reactive in self.reactives.snapshot_changed::<W>(world) {
+    pub fn update_reactives(&mut self, world: &mut W) {
+        for reactive in self.reactives.snapshot_changed(world) {
             let element_id = reactive.element_id();
 
             // The holder may have been discarded earlier this flush
@@ -160,7 +158,7 @@ impl Fynix {
             // drop any uncommitted style changes so they do not leak.
             let child = {
                 let mut ctx =
-                    FynixCtx::new(self, world, reactive.style_id());
+                    self.create_ctx(world, reactive.style_id());
                 reactive.build(&mut ctx)
             };
             self.styles.clear_builder();
@@ -187,7 +185,7 @@ impl Fynix {
     /// Returns a [`FynixCtx`] rooted at the top of the style
     /// hierarchy.
     #[inline]
-    pub fn root_ctx<'f, 'w, W>(
+    pub fn root_ctx<'f, 'w>(
         &'f mut self,
         world: &'w mut W,
     ) -> FynixCtx<'f, 'w, W> {
@@ -199,7 +197,7 @@ impl Fynix {
     /// Use [`Self::root_ctx`] unless you need to resume building from
     /// a previously committed [`StyleId`].
     #[inline]
-    pub fn create_ctx<'f, 'w, W>(
+    pub fn create_ctx<'f, 'w>(
         &'f mut self,
         world: &'w mut W,
         parent_style: Option<StyleId>,
@@ -208,7 +206,7 @@ impl Fynix {
     }
 }
 
-impl Default for Fynix {
+impl<W> Default for Fynix<W> {
     fn default() -> Self {
         Self::new()
     }

--- a/crates/fynix/src/reactive.rs
+++ b/crates/fynix/src/reactive.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 
 use hashbrown::HashMap;
 use rectree::{Constraint, NodeContext, Size, Vec2};
-use typarena::type_pool::{PoolKey, TypePool};
+use sparse_map::{Key, SparseMap};
 
 use crate::ctx::FynixCtx;
 use crate::element::layout::ElementNodes;
@@ -10,25 +10,26 @@ use crate::element::{Element, ElementBuild, ElementId};
 use crate::init::Init;
 use crate::style::StyleId;
 
-pub struct Reactives {
-    reactives: TypePool,
+/// Store of every reactive bound to the element tree, fixed to the
+/// single world type `W`.
+///
+/// Backed by a concrete [`SparseMap`] keyed by [`ReactiveId`].
+pub struct Reactives<W> {
+    reactives: SparseMap<Reactive<W>>,
     /// Reverse index from each holder element to its reactive, used
     /// to remove the reactive when the element is removed.
     by_element: HashMap<ElementId, ReactiveId>,
 }
 
-impl Reactives {
+impl<W> Reactives<W> {
     pub fn new() -> Self {
         Self {
-            reactives: TypePool::new(),
+            reactives: SparseMap::new(),
             by_element: HashMap::new(),
         }
     }
 
-    pub fn add<W: 'static>(
-        &mut self,
-        reactive: Reactive<W>,
-    ) -> ReactiveId {
+    pub fn add(&mut self, reactive: Reactive<W>) -> ReactiveId {
         let element_id = reactive.element_id;
         let reactive_id = ReactiveId(self.reactives.insert(reactive));
         self.by_element.insert(element_id, reactive_id);
@@ -44,29 +45,29 @@ impl Reactives {
     ) {
         if let Some(reactive_id) = self.by_element.remove(element_id)
         {
-            self.reactives.dyn_remove(&reactive_id.0);
+            self.reactives.remove(&reactive_id.0);
         }
     }
 
-    /// Snapshots every reactive of world type `W` whose `changed_fn`
-    /// reports a change against `world`.
+    /// Snapshots every reactive whose `changed_fn` reports a change
+    /// against `world`.
     ///
     /// [`Reactive`] is [`Copy`], so the snapshot detaches the changed
-    /// reactives from the pool, letting the caller borrow the rest of
-    /// `Fynix` while it rebuilds each one.
-    pub(crate) fn snapshot_changed<W: 'static>(
+    /// reactives from the store, letting the caller borrow the rest
+    /// of `Fynix` while it rebuilds each one.
+    pub(crate) fn snapshot_changed(
         &self,
         world: &W,
     ) -> Vec<Reactive<W>> {
         self.reactives
-            .iter::<Reactive<W>>()
+            .iter()
             .filter(|reactive| reactive.is_changed(world))
             .copied()
             .collect()
     }
 }
 
-impl Default for Reactives {
+impl<W> Default for Reactives<W> {
     fn default() -> Self {
         Self::new()
     }
@@ -157,16 +158,106 @@ impl<W> Clone for Reactive<W> {
 
 /// Generational ID for reactive instances.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct ReactiveId(PoolKey);
+pub struct ReactiveId(Key);
 
 impl ReactiveId {
     /// A sentinel id that will never refer to a live reactive.
-    pub const PLACEHOLDER: Self = Self(PoolKey::PLACEHOLDER);
+    pub const PLACEHOLDER: Self = Self(Key::PLACEHOLDER);
 }
 
 impl core::ops::Deref for ReactiveId {
-    type Target = PoolKey;
-    fn deref(&self) -> &PoolKey {
+    type Target = Key;
+    fn deref(&self) -> &Key {
         &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Fynix;
+    use crate::element::ElementBuild;
+    use crate::element::layout::ElementNodes;
+
+    #[derive(Init, Element, Clone)]
+    struct Counter {
+        n: u32,
+    }
+
+    impl ElementBuild for Counter {
+        fn build(
+            &self,
+            _id: &ElementId,
+            constraint: Constraint,
+            _nodes: &mut ElementNodes,
+        ) -> Size {
+            constraint.min
+        }
+    }
+
+    #[derive(Default)]
+    struct World {
+        changed: bool,
+        value: u32,
+    }
+
+    /// The reactive captures `value` at build time and only rebuilds
+    /// when `changed` reports true, picking up the new value then.
+    #[test]
+    fn rebuilds_only_when_changed() {
+        let mut world = World {
+            changed: false,
+            value: 1,
+        };
+        let mut fynix = Fynix::<World>::new();
+
+        let holder = {
+            let mut ctx = fynix.root_ctx(&mut world);
+            ctx.reactive(
+                |w| w.changed,
+                |ctx| {
+                    let value = ctx.world.value;
+                    Some(
+                        ctx.add_with::<Counter>(|c, _| c.n = value)
+                            .id(),
+                    )
+                },
+            )
+            .id()
+        };
+
+        let child_n = |fynix: &Fynix<World>| {
+            let child = fynix
+                .elements
+                .get_typed::<ReactiveElement>(&holder)
+                .unwrap()
+                .child
+                .unwrap();
+            (
+                child,
+                fynix
+                    .elements
+                    .get_typed::<Counter>(&child)
+                    .unwrap()
+                    .n,
+            )
+        };
+
+        // Initial build captured value 1.
+        let (first_child, n) = child_n(&fynix);
+        assert_eq!(n, 1);
+
+        // Value changes but `changed` is false: no rebuild.
+        world.value = 2;
+        fynix.update_reactives(&mut world);
+        let (child, n) = child_n(&fynix);
+        assert_eq!(child, first_child);
+        assert_eq!(n, 1);
+
+        // Flip `changed`: subtree rebuilds with the new value.
+        world.changed = true;
+        fynix.update_reactives(&mut world);
+        let (_, n) = child_n(&fynix);
+        assert_eq!(n, 2);
     }
 }

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -380,6 +380,6 @@ pub struct TextContext {
 
 /// Initialize the resources needed for the elements in this crate to
 /// work correctly.
-pub fn init_resources(fynix: &mut Fynix) {
+pub fn init_resources<W>(fynix: &mut Fynix<W>) {
     fynix.resources.init::<TextContext>();
 }

--- a/examples/vello_winit_examples/examples/hello_world.rs
+++ b/examples/vello_winit_examples/examples/hello_world.rs
@@ -5,53 +5,131 @@ use fynix::prelude::*;
 use fynix_elements::parley::FontStyle;
 use fynix_elements::parley::fontique::{Blob, GenericFamily};
 use fynix_elements::{
-    Button, Horizontal, Label, Pad, TextContext, Vertical,
+    Button, Horizontal, Label, Pad, TextContext, Vertical, WindowSize,
 };
 use vello::peniko::Color;
 use vello::peniko::color::palette::css;
-use vello_winit_examples::{FynixDemo, VelloWinitApp};
+use vello_winit_examples::{DemoWorld, VelloWinitApp};
 use winit::event_loop::EventLoop;
 
 const FONT: &[u8] = include_bytes!("../assets/Inter-Regular.ttf");
 
 fn main() {
     let event_loop = EventLoop::new().unwrap();
-    let mut app = VelloWinitApp::new(HelloWorld);
+    let mut app = VelloWinitApp::new(HelloWorld::default());
     event_loop.run_app(&mut app).unwrap();
 }
 
-struct HelloWorld;
+fn main_layout(ctx: &mut FynixCtx<HelloWorld>) -> ElementId {
+    ctx.add_with::<Pad>(|p, ctx| {
+        *p = Pad::all(20.0);
+        p.set_child(ctx.add_with::<Vertical>(|v, ctx| {
+            ctx.set(path!(<Label>::fill), css::WHITE_SMOKE.into());
+
+            // Reactive FPS counter: rebuilt only when the value
+            // changes (see `DemoWorld::update`).
+            v.add(ctx.reactive(
+                |w| w.fps_changed,
+                |ctx| {
+                    let fps = ctx.world.fps;
+                    Some(
+                        ctx.add_with::<Label>(|label, _| {
+                            label.text = format!("FPS: {fps}");
+                            label.font_size = 20.0;
+                        })
+                        .id(),
+                    )
+                },
+            ));
+
+            v.add(ctx.add_with::<Label>(|label, _ctx| {
+                label.text = "Hello, Fynix!".into();
+                label.font_size = 24.0;
+            }));
+            v.add(ctx.add_with::<Label>(|label, _ctx| {
+                label.text =
+                    "Lorem ipsum dolor sit amet consectetur \
+                     adipiscing elit. Placerat in id cursus mi \
+                     pretium tellus duis. Urna tempor pulvinar \
+                     vivamus fringilla lacus nec metus. Integer \
+                     nunc posuere ut hendrerit semper vel class."
+                        .into();
+            }));
+
+            v.add(ctx.add_with::<Horizontal>(|v, ctx| {
+                ctx.set(path!(<Label>::font_size), 16.0);
+                ctx.set(path!(<Label>::fill), css::AQUA.into());
+
+                v.add(ctx.add_with::<Label>(|label, _ctx| {
+                    label.text = "Hello, Fynix!".into();
+                }));
+
+                ctx.set(
+                    path!(<Label>::font_style),
+                    FontStyle::Italic,
+                );
+
+                v.add(ctx.add_with::<Label>(|label, _ctx| {
+                    label.text = "Horizontal continuation.".into();
+                }));
+                v.add(ctx.add_with::<Label>(|label, _ctx| {
+                    label.text = "Another label!".into();
+                }));
+            }));
+
+            v.add(ctx.compose(TextButton { label: "Press me!" }));
+            v.add(ctx.compose(TextButton {
+                label: "Other Button!",
+            }));
+            v.add(ctx.compose_with(
+                TextButton {
+                    label: "Green Button?!",
+                },
+                |s| s.bg_color = Some(css::GREEN),
+            ));
+        }));
+    })
+    .id()
+}
 
 /// Demo world: the current FPS, recomputed each frame from the
-/// frame delta.
+/// frame delta, plus the latest window size.
 #[derive(Default)]
-struct DemoWorld {
+struct HelloWorld {
     fps: u32,
     /// True only on the frame `fps` changed, so the reactive counter
     /// rebuilds just then.
     fps_changed: bool,
+    /// Latest window size pushed in by the backend.
+    window_size: Size,
+    /// True when `window_size` changed, so the reactive window
+    /// subtree rebuilds just then.
+    window_size_changed: bool,
 }
 
-impl FynixDemo for HelloWorld {
-    type World = DemoWorld;
-
+impl DemoWorld for HelloWorld {
     fn window_title(&self) -> &'static str {
         "Hello, Fynix!"
     }
 
-    fn update(&mut self, world: &mut DemoWorld, dt: Duration) {
-        world.fps_changed = false;
+    fn update(&mut self, dt: Duration) {
+        self.fps_changed = false;
         let secs = dt.as_secs_f32();
         if secs > 0.0 {
             let fps = (1.0 / secs).round() as u32;
-            if fps != world.fps {
-                world.fps = fps;
-                world.fps_changed = true;
+            if fps != self.fps {
+                self.fps = fps;
+                self.fps_changed = true;
             }
         }
     }
 
-    fn init(&mut self, fynix: &mut Fynix) {
+    fn set_window_size(&mut self, size: Size) {
+        self.window_size = size;
+        self.window_size_changed = true;
+    }
+
+    fn init(&mut self, fynix: &mut Fynix<Self>) {
         fynix_elements::init_resources(fynix);
         if let Some(text_cx) =
             fynix.resources.get_mut::<TextContext>()
@@ -66,79 +144,23 @@ impl FynixDemo for HelloWorld {
         }
     }
 
-    fn build(&mut self, ctx: &mut FynixCtx<DemoWorld>) -> ElementId {
-        ctx.add_with::<Pad>(|p, ctx| {
-            *p = Pad::all(20.0);
-            p.set_child(ctx.add_with::<Vertical>(|v, ctx| {
-                ctx.set(
-                    path!(<Label>::fill),
-                    css::WHITE_SMOKE.into(),
-                );
-
-                // Reactive FPS counter: rebuilt only when the value
-                // changes (see `DemoWorld::update`).
-                v.add(ctx.reactive(
-                    |w| w.fps_changed,
-                    |ctx| {
-                        let fps = ctx.world.fps;
-                        Some(
-                            ctx.add_with::<Label>(|label, _| {
-                                label.text = format!("FPS: {fps}");
-                                label.font_size = 20.0;
-                            })
-                            .id(),
-                        )
-                    },
-                ));
-
-                v.add(ctx.add_with::<Label>(|label, _ctx| {
-                    label.text = "Hello, Fynix!".into();
-                    label.font_size = 24.0;
-                }));
-                v.add(ctx.add_with::<Label>(|label, _ctx| {
-                    label.text =
-                        "Lorem ipsum dolor sit amet consectetur \
-                         adipiscing elit. Placerat in id cursus mi \
-                         pretium tellus duis. Urna tempor pulvinar \
-                         vivamus fringilla lacus nec metus. Integer \
-                         nunc posuere ut hendrerit semper vel class."
-                            .into();
-                }));
-
-                v.add(ctx.add_with::<Horizontal>(|v, ctx| {
-                    ctx.set(path!(<Label>::font_size), 16.0);
-                    ctx.set(path!(<Label>::fill), css::AQUA.into());
-
-                    v.add(ctx.add_with::<Label>(|label, _ctx| {
-                        label.text = "Hello, Fynix!".into();
-                    }));
-
-                    ctx.set(
-                        path!(<Label>::font_style),
-                        FontStyle::Italic,
-                    );
-
-                    v.add(ctx.add_with::<Label>(|label, _ctx| {
-                        label.text =
-                            "Horizontal continuation.".into();
-                    }));
-                    v.add(ctx.add_with::<Label>(|label, _ctx| {
-                        label.text = "Another label!".into();
-                    }));
-                }));
-
-                v.add(ctx.compose(TextButton { label: "Press me!" }));
-                v.add(ctx.compose(TextButton {
-                    label: "Other Button!",
-                }));
-                v.add(ctx.compose_with(
-                    TextButton {
-                        label: "Green Button?!",
-                    },
-                    |s| s.bg_color = Some(css::GREEN),
-                ));
-            }));
-        })
+    fn build(ctx: &mut FynixCtx<Self>) -> ElementId {
+        // Reactive window subtree: rebuilt only when the window size
+        // changes (see `set_window_size`).
+        ctx.reactive(
+            |w| w.window_size_changed,
+            |ctx| {
+                let size = ctx.world.window_size;
+                ctx.world.window_size_changed = false;
+                Some(
+                    ctx.add_with::<WindowSize>(|win, ctx| {
+                        win.size = size;
+                        win.set_child(main_layout(ctx));
+                    })
+                    .id(),
+                )
+            },
+        )
         .id()
     }
 }
@@ -158,13 +180,13 @@ struct TextButton<'a> {
     pub label: &'a str,
 }
 
-impl Composer<DemoWorld> for TextButton<'_> {
+impl Composer<HelloWorld> for TextButton<'_> {
     type Style = TextButtonStyle;
 
     fn compose(
         self,
         style: TextButtonStyle,
-        ctx: &mut FynixCtx<'_, '_, DemoWorld>,
+        ctx: &mut FynixCtx<'_, '_, HelloWorld>,
     ) -> ElementId {
         ctx.add_with::<Button>(|b, ctx| {
             b.corner_radius = style.corner_radius;

--- a/examples/vello_winit_examples/src/lib.rs
+++ b/examples/vello_winit_examples/src/lib.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use fynix::prelude::*;
-use fynix_elements::WindowSize;
 use imaging_vello::VelloSceneSink;
 use vello::kurbo::Rect;
 use vello::peniko::Color;
@@ -17,11 +16,7 @@ use winit::event::WindowEvent;
 use winit::event_loop::ActiveEventLoop;
 use winit::window::Window;
 
-pub trait FynixDemo {
-    /// World state passed to [`Self::build`] and advanced each frame
-    /// in [`Self::update`]. Reactive scopes read from it.
-    type World: Default + 'static;
-
+pub trait DemoWorld: Sized {
     fn window_title(&self) -> &'static str {
         "Fynix"
     }
@@ -30,21 +25,26 @@ pub trait FynixDemo {
         (800.0, 600.0)
     }
 
-    fn init(&mut self, _fynix: &mut Fynix) {}
+    /// Registers any resources or assets the demo needs before the
+    /// initial build.
+    fn init(&mut self, fynix: &mut Fynix<Self>);
 
     /// Advances world state before reactive scopes are updated.
     /// `dt` is the time elapsed since the previous frame.
-    fn update(&mut self, _world: &mut Self::World, _dt: Duration) {}
+    fn update(&mut self, dt: Duration);
 
-    fn build(&mut self, ctx: &mut FynixCtx<Self::World>)
-    -> ElementId;
+    /// Pushes the new window size into the world whenever it changes.
+    fn set_window_size(&mut self, size: Size);
+
+    /// Builds the initial tree. The world is already borrowed by
+    /// `ctx`, so read it via `ctx.world`.
+    fn build(ctx: &mut FynixCtx<Self>) -> ElementId;
 }
 
-pub struct VelloWinitApp<'s, D: FynixDemo> {
-    fynix: Fynix,
+pub struct VelloWinitApp<'s, W: DemoWorld> {
+    fynix: Fynix<W>,
+    world: W,
     root_id: ElementId,
-    demo: D,
-    world: D::World,
     last_frame: Instant,
     context: RenderContext,
     renderer: Option<Renderer>,
@@ -60,24 +60,19 @@ pub enum RenderState<'s> {
     },
 }
 
-impl<D: FynixDemo> VelloWinitApp<'_, D> {
-    pub fn new(mut demo: D) -> Self {
+impl<W: DemoWorld> VelloWinitApp<'_, W> {
+    pub fn new(mut world: W) -> Self {
         let mut fynix = Fynix::new();
-        demo.init(&mut fynix);
+        world.init(&mut fynix);
 
-        let mut world = D::World::default();
         let root_id = {
             let mut ctx = fynix.root_ctx(&mut world);
-            ctx.add_with::<WindowSize>(|w, ctx| {
-                w.set_child(demo.build(ctx));
-            })
-            .id()
+            W::build(&mut ctx)
         };
 
         Self {
             fynix,
             root_id,
-            demo,
             world,
             last_frame: Instant::now(),
             context: RenderContext::new(),
@@ -112,31 +107,13 @@ impl<D: FynixDemo> VelloWinitApp<'_, D> {
             );
         }
 
-        // Resize the root only when the window size changes, marking
-        // it dirty so the whole tree re-lays out then (and on the
-        // first frame).
-        let size = Size::new(phys.width as f32, phys.height as f32);
-        let resized = self
-            .fynix
-            .elements
-            .get_typed_mut::<WindowSize>(&self.root_id)
-            .is_some_and(|root| {
-                let changed = root.size.width != size.width
-                    || root.size.height != size.height;
-                root.size = size;
-                changed
-            });
-        if resized {
-            self.fynix.elements.mark_dirty(self.root_id);
-        }
-
         // Advance world state with this frame's delta, then rebuild
         // any reactives whose inputs changed, before layout.
         let now = Instant::now();
         let dt = now.duration_since(self.last_frame);
         self.last_frame = now;
-        self.demo.update(&mut self.world, dt);
-        self.fynix.update_reactives::<D::World>(&mut self.world);
+        self.world.update(dt);
+        self.fynix.update_reactives(&mut self.world);
 
         self.fynix.layout();
 
@@ -204,18 +181,18 @@ impl<D: FynixDemo> VelloWinitApp<'_, D> {
     }
 }
 
-impl<D: FynixDemo> ApplicationHandler for VelloWinitApp<'_, D> {
+impl<D: DemoWorld> ApplicationHandler for VelloWinitApp<'_, D> {
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         let RenderState::Suspended(cached_window) = &mut self.state
         else {
             return;
         };
 
-        let (w, h) = self.demo.initial_logical_size();
+        let (w, h) = self.world.initial_logical_size();
         let window = cached_window.take().unwrap_or_else(|| {
             let attr = Window::default_attributes()
                 .with_inner_size(LogicalSize::new(w, h))
-                .with_title(self.demo.window_title());
+                .with_title(self.world.window_title());
             Arc::new(event_loop.create_window(attr).unwrap())
         });
 
@@ -278,7 +255,10 @@ impl<D: FynixDemo> ApplicationHandler for VelloWinitApp<'_, D> {
                     window.request_redraw();
                 }
             }
-            WindowEvent::Resized(_) => {
+            WindowEvent::Resized(phys) => {
+                let size =
+                    Size::new(phys.width as f32, phys.height as f32);
+                self.world.set_window_size(size);
                 if let RenderState::Active { window, .. } =
                     &self.state
                 {


### PR DESCRIPTION
Greatly simplifies reactivity & binding & events. This simplifies the amount of bookkeeping needed for a multi-world backend support. A huge win is that users would only need to call a single `update` everyframe rather than trying to remember to call update for all the different worlds every frame.

Single world backend assumption allows many optimizations too!

This topic can be revisited in the future if there is ever a huge need for a multi-world backend UI framework. (More importantly, what are the pros & cons??)