### PR TITLE
Add binding

### DIFF
--- a/crates/fynix/src/binding.rs
+++ b/crates/fynix/src/binding.rs
@@ -1,0 +1,198 @@
+use alloc::vec::Vec;
+
+use field_path::accessor::func_pointers::{MutFn, MutFnPtr};
+use hashbrown::HashMap;
+use sparse_map::{Key, SparseMap};
+
+use crate::element::{Element, ElementId, Elements};
+
+/// Store of every reactive bound to the element tree, fixed to the
+/// single world type `W`.
+///
+/// Backed by a concrete [`SparseMap`] keyed by [`BindingId`].
+pub struct Bindings<W> {
+    bindings: SparseMap<Binding<W>>,
+    /// Reverse index from each holder element to its reactive, used
+    /// to remove the reactive when the element is removed.
+    element_map: HashMap<ElementId, BindingId>,
+}
+
+impl<W> Bindings<W> {
+    pub fn new() -> Self {
+        Self {
+            bindings: SparseMap::new(),
+            element_map: HashMap::new(),
+        }
+    }
+
+    pub fn add(&mut self, binding: Binding<W>) -> BindingId {
+        let element_id = binding.element_id;
+        let binding_id = BindingId(self.bindings.insert(binding));
+        self.element_map.insert(element_id, binding_id);
+
+        binding_id
+    }
+
+    /// Removes the binding bound to `element_id`, if any.
+    ///
+    /// A no-op for elements that do not own a binding.
+    pub(crate) fn remove_for_element(
+        &mut self,
+        element_id: &ElementId,
+    ) {
+        if let Some(binding_id) = self.element_map.remove(element_id)
+        {
+            self.bindings.remove(&binding_id.0);
+        }
+    }
+
+    /// Snapshots every binding whose `changed_fn` reports a change
+    /// against `world`.
+    ///
+    /// [`Binding`] is [`Copy`], so the snapshot detaches the changed
+    /// bindings from the store, letting the caller borrow the rest
+    /// of `Fynix` while it rebuilds each one.
+    pub(crate) fn snapshot_changed(
+        &self,
+        world: &W,
+    ) -> Vec<Binding<W>> {
+        self.bindings
+            .iter()
+            .filter(|binding| binding.is_changed(world))
+            .copied()
+            .collect()
+    }
+}
+
+impl<W> Default for Bindings<W> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug)]
+pub struct Binding<W> {
+    /// Function that determines if something has changed and require
+    /// a re-creation of [`ReactiveElement::child`].
+    changed_fn: ChangedFn<W>,
+    get_fn: GetFnPtr,
+    mut_fn: MutFnPtr,
+    /// Apply the binding value.
+    apply_fn: ApplyFn<W>,
+    element_id: ElementId,
+}
+
+impl<W> Binding<W> {
+    pub(crate) fn new<E: Element, T>(
+        changed_fn: ChangedFn<W>,
+        get_fn: GetFn<W, T>,
+        mut_fn: MutFn<E, T>,
+        element_id: ElementId,
+    ) -> Self {
+        Self {
+            changed_fn,
+            get_fn: GetFnPtr::new(get_fn),
+            mut_fn: MutFnPtr::new(mut_fn),
+            apply_fn: apply::<W, E, T>,
+            element_id,
+        }
+    }
+
+    pub fn element_id(&self) -> ElementId {
+        self.element_id
+    }
+
+    pub fn is_changed(&self, world: &W) -> bool {
+        (self.changed_fn)(world)
+    }
+
+    pub fn apply(&self, elements: &mut Elements, world: &W) {
+        (self.apply_fn)(
+            world,
+            elements,
+            &self.element_id,
+            self.get_fn,
+            self.mut_fn,
+        )
+    }
+}
+
+impl<W> Copy for Binding<W> {}
+
+impl<W> Clone for Binding<W> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+pub type ChangedFn<W> = fn(&W) -> bool;
+
+pub type ApplyFn<W> = fn(
+    world: &W,
+    elements: &mut Elements,
+    id: &ElementId,
+    get_fn: GetFnPtr,
+    get_mut: MutFnPtr,
+);
+
+fn apply<W, E: Element, T>(
+    world: &W,
+    elements: &mut Elements,
+    id: &ElementId,
+    get_fn: GetFnPtr,
+    get_mut: MutFnPtr,
+) {
+    if let Some(element) = elements.get_typed_mut::<E>(id) {
+        let get_fn = unsafe { get_fn.typed_unchecked::<W, T>() };
+        let get_mut = unsafe { get_mut.typed_unchecked::<E, T>() };
+
+        let v = get_fn(world);
+        *get_mut(element) = v;
+    }
+    elements.mark_dirty(*id);
+}
+
+/// A type-erased mutable field accessor function pointer.
+#[derive(Debug, Clone, Copy)]
+pub struct GetFnPtr(*const ());
+
+unsafe impl Send for GetFnPtr {}
+unsafe impl Sync for GetFnPtr {}
+
+impl GetFnPtr {
+    /// Creates a new erased type of [`MutFn<S, T>`].
+    pub const fn new<W, T>(f: GetFn<W, T>) -> Self {
+        Self(f as *const ())
+    }
+
+    /// Re-interprets this pointer as a typed [`MutFn`] without
+    /// checking type correctness.
+    ///
+    /// # Safety
+    ///
+    /// Undefined behavior if `S` and `T` do not match the types used
+    /// when constructing this pointer.
+    pub const unsafe fn typed_unchecked<S, T>(&self) -> GetFn<S, T> {
+        unsafe {
+            core::mem::transmute::<*const (), GetFn<S, T>>(self.0)
+        }
+    }
+}
+
+pub type GetFn<W, T> = fn(&W) -> T;
+
+/// Generational ID for reactive instances.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BindingId(Key);
+
+impl BindingId {
+    /// A sentinel id that will never refer to a live reactive.
+    pub const PLACEHOLDER: Self = Self(Key::PLACEHOLDER);
+}
+
+impl core::ops::Deref for BindingId {
+    type Target = Key;
+    fn deref(&self) -> &Key {
+        &self.0
+    }
+}

--- a/crates/fynix/src/binding.rs
+++ b/crates/fynix/src/binding.rs
@@ -1,3 +1,13 @@
+//! Field bindings: in-place updates of a single element's field,
+//! driven by world change detection.
+//!
+//! A binding is the lightweight counterpart to a reactive scope.
+//! Where a scope rebuilds a whole subtree, a binding reads one value
+//! from the world and writes it into one element field, then marks
+//! that element dirty. Bindings are attached per instance via
+//! [`ElementCtx::bind`](crate::ctx::ElementCtx::bind) and applied
+//! each frame by [`Fynix::update_reactives`](crate::Fynix).
+
 use alloc::vec::Vec;
 
 use field_path::accessor::func_pointers::{MutFn, MutFnPtr};
@@ -6,18 +16,19 @@ use sparse_map::{Key, SparseMap};
 
 use crate::element::{Element, ElementId, Elements};
 
-/// Store of every reactive bound to the element tree, fixed to the
+/// Store of every binding attached to the element tree, fixed to the
 /// single world type `W`.
 ///
 /// Backed by a concrete [`SparseMap`] keyed by [`BindingId`].
 pub struct Bindings<W> {
     bindings: SparseMap<Binding<W>>,
-    /// Reverse index from each holder element to its reactive, used
-    /// to remove the reactive when the element is removed.
+    /// Reverse index from each element to its binding, used to
+    /// remove the binding when the element is removed.
     element_map: HashMap<ElementId, BindingId>,
 }
 
 impl<W> Bindings<W> {
+    /// Creates an empty store.
     pub fn new() -> Self {
         Self {
             bindings: SparseMap::new(),
@@ -25,6 +36,7 @@ impl<W> Bindings<W> {
         }
     }
 
+    /// Registers `binding`, returning its [`BindingId`].
     pub fn add(&mut self, binding: Binding<W>) -> BindingId {
         let element_id = binding.element_id;
         let binding_id = BindingId(self.bindings.insert(binding));
@@ -70,15 +82,24 @@ impl<W> Default for Bindings<W> {
     }
 }
 
+/// A single field binding: reads `T` from the world and writes it
+/// into element `E`'s field when the source changes.
+///
+/// `get_fn` and `mut_fn` are type-erased to keep `Binding` free of
+/// the `E`/`T` parameters; `apply_fn` is the monomorphized writer
+/// that restores them and performs the write.
 #[derive(Debug)]
 pub struct Binding<W> {
-    /// Function that determines if something has changed and require
-    /// a re-creation of [`ReactiveElement::child`].
+    /// Reports whether the bound source changed since the last
+    /// apply.
     changed_fn: ChangedFn<W>,
+    /// Type-erased `fn(&W) -> T` reading the new value.
     get_fn: GetFnPtr,
+    /// Type-erased `fn(&mut E) -> &mut T` to the target field.
     mut_fn: MutFnPtr,
-    /// Apply the binding value.
+    /// Monomorphized writer that re-types and applies the value.
     apply_fn: ApplyFn<W>,
+    /// The element whose field this binding writes.
     element_id: ElementId,
 }
 
@@ -98,14 +119,18 @@ impl<W> Binding<W> {
         }
     }
 
+    /// The element this binding writes into.
     pub fn element_id(&self) -> ElementId {
         self.element_id
     }
 
+    /// Returns `true` if the bound source changed.
     pub fn is_changed(&self, world: &W) -> bool {
         (self.changed_fn)(world)
     }
 
+    /// Reads the new value from `world` and writes it into the
+    /// element, marking it dirty.
     pub fn apply(&self, elements: &mut Elements, world: &W) {
         (self.apply_fn)(
             world,
@@ -125,8 +150,12 @@ impl<W> Clone for Binding<W> {
     }
 }
 
+/// Reports whether a binding's source changed since the last apply.
 pub type ChangedFn<W> = fn(&W) -> bool;
 
+/// Type-erased writer stored on a [`Binding`]. Monomorphized per
+/// `(W, E, T)`, it restores the erased accessors and performs the
+/// field write.
 pub type ApplyFn<W> = fn(
     world: &W,
     elements: &mut Elements,
@@ -135,6 +164,9 @@ pub type ApplyFn<W> = fn(
     get_mut: MutFnPtr,
 );
 
+/// Reads `T` from `world`, writes it into element `E`'s field, and
+/// marks the element dirty. A no-op write if the element is absent
+/// or of a different type, but it is still marked dirty.
 fn apply<W, E: Element, T>(
     world: &W,
     elements: &mut Elements,
@@ -152,7 +184,8 @@ fn apply<W, E: Element, T>(
     elements.mark_dirty(*id);
 }
 
-/// A type-erased mutable field accessor function pointer.
+/// A type-erased [`GetFn`] (the world value reader) stored on a
+/// [`Binding`] so it carries no `T` parameter.
 #[derive(Debug, Clone, Copy)]
 pub struct GetFnPtr(*const ());
 
@@ -160,12 +193,12 @@ unsafe impl Send for GetFnPtr {}
 unsafe impl Sync for GetFnPtr {}
 
 impl GetFnPtr {
-    /// Creates a new erased type of [`MutFn<S, T>`].
+    /// Erases a [`GetFn<W, T>`].
     pub const fn new<W, T>(f: GetFn<W, T>) -> Self {
         Self(f as *const ())
     }
 
-    /// Re-interprets this pointer as a typed [`MutFn`] without
+    /// Re-interprets this pointer as a typed [`GetFn`] without
     /// checking type correctness.
     ///
     /// # Safety
@@ -179,14 +212,15 @@ impl GetFnPtr {
     }
 }
 
+/// Reads a value of type `T` from the world.
 pub type GetFn<W, T> = fn(&W) -> T;
 
-/// Generational ID for reactive instances.
+/// Generational ID for binding instances.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct BindingId(Key);
 
 impl BindingId {
-    /// A sentinel id that will never refer to a live reactive.
+    /// A sentinel id that will never refer to a live binding.
     pub const PLACEHOLDER: Self = Self(Key::PLACEHOLDER);
 }
 

--- a/crates/fynix/src/composer.rs
+++ b/crates/fynix/src/composer.rs
@@ -6,7 +6,7 @@ use crate::style::Stylable;
 /// Builds a subtree from caller-supplied inputs and a pre-styled data
 /// struct.
 ///
-/// Unlike [`Element`](crate::element::Element), a composer is not
+/// Unlike [`Element`], a composer is not
 /// stored in the element tree. It may carry lifetime parameters (e.g.
 /// references into the world) because it is consumed immediately
 /// inside [`FynixCtx::compose`].
@@ -19,9 +19,13 @@ use crate::style::Stylable;
 /// [`FynixCtx::compose_with`] additionally runs an inline closure
 /// that can override individual fields after the chain is applied.
 pub trait Composer<W> {
+    /// The pre-styled input struct, built and styled by
+    /// [`FynixCtx::compose`] before [`Self::compose`] runs.
     type Style: Stylable;
+    /// The root element type the composer produces.
     type Element: Element;
 
+    /// Builds the subtree and returns a handle to its root element.
     fn compose(
         self,
         style: Self::Style,

--- a/crates/fynix/src/composer.rs
+++ b/crates/fynix/src/composer.rs
@@ -1,5 +1,6 @@
 use crate::ctx::FynixCtx;
-use crate::element::ElementId;
+use crate::element::Element;
+use crate::element::storage::ElementHandle;
 use crate::style::Stylable;
 
 /// Builds a subtree from caller-supplied inputs and a pre-styled data
@@ -19,12 +20,13 @@ use crate::style::Stylable;
 /// that can override individual fields after the chain is applied.
 pub trait Composer<W> {
     type Style: Stylable;
+    type Element: Element;
 
     fn compose(
         self,
         style: Self::Style,
         ctx: &mut FynixCtx<'_, '_, W>,
-    ) -> ElementId
+    ) -> ElementHandle<Self::Element>
     where
         Self: Sized;
 }

--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -236,6 +236,12 @@ impl<W> FynixCtx<'_, '_, W> {
     }
 }
 
+/// A freshly added element of type `E`, returned by
+/// [`FynixCtx::add`] and friends and borrowed for one build
+/// statement to configure it.
+///
+/// Carries `E` so configuration can be type-checked against the
+/// element. Converts into its [`ElementId`] or [`ElementHandle`].
 pub struct ElementCtx<'f, W, E: Element> {
     fynix: &'f mut Fynix<W>,
     handle: ElementHandle<E>,
@@ -249,6 +255,15 @@ impl<'f, W, E: Element> ElementCtx<'f, W, E> {
         Self { fynix, handle }
     }
 
+    /// Binds one of this element's fields to the world.
+    ///
+    /// When `changed_fn` reports a change, `get_fn` reads the new
+    /// value from the world and it is written through `mut_fn` into
+    /// this element, which is then marked dirty. Unlike a reactive
+    /// scope, nothing is rebuilt: only the field is updated in place.
+    ///
+    /// Chainable, and applied each frame by
+    /// [`Fynix::update_reactives`](crate::Fynix::update_reactives).
     pub fn bind<T>(
         self,
         changed_fn: binding::ChangedFn<W>,

--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -1,14 +1,17 @@
+use field_path::accessor::func_pointers::MutFn;
 use field_path::field_accessor::FieldAccessor;
 
-use crate::Fynix;
+use crate::binding::{Binding, GetFn};
 use crate::composer::Composer;
+use crate::element::storage::ElementHandle;
 use crate::element::{Element, ElementId};
 use crate::init::Init;
-use crate::interaction::{HandlerFn, Interactions};
+use crate::interaction::HandlerFn;
 use crate::reactive::{
     BuildFn, ChangedFn, Reactive, ReactiveElement,
 };
 use crate::style::{Stylable, StyleId, StyleValue};
+use crate::{Fynix, binding};
 
 /// Build-time context for constructing the element tree and declaring
 /// style defaults.
@@ -55,10 +58,10 @@ impl<W> FynixCtx<'_, '_, W> {
     /// Elements created with `add` dont own any styles, so their
     /// `primary_style` is `None`
     #[must_use]
-    pub fn add<E: Element>(&mut self) -> ElementHandle<'_> {
+    pub fn add<E: Element>(&mut self) -> ElementCtx<'_, W, E> {
         let element = self.create_styled::<E>();
         let id = self.fynix.elements.add(element, None);
-        ElementHandle::new(&mut self.fynix.interactions, id)
+        ElementCtx::new(self.fynix, id)
     }
 
     /// Like [`Self::add`], but also runs `scope` for inline mutations
@@ -67,13 +70,13 @@ impl<W> FynixCtx<'_, '_, W> {
     pub fn add_with<E: Element>(
         &mut self,
         scope: impl FnOnce(&mut E, &mut Self),
-    ) -> ElementHandle<'_> {
+    ) -> ElementCtx<'_, W, E> {
         let mut element = self.create_styled::<E>();
         let id = self.style_scoped(|ctx| {
             scope(&mut element, ctx);
             ctx.fynix.elements.add(element, ctx.primary_style.take())
         });
-        ElementHandle::new(&mut self.fynix.interactions, id)
+        ElementCtx::new(self.fynix, id)
     }
 
     /// Runs `composer`, passing it a style instance built from the
@@ -85,11 +88,11 @@ impl<W> FynixCtx<'_, '_, W> {
     pub fn compose<C: Composer<W>>(
         &mut self,
         composer: C,
-    ) -> ElementHandle<'_> {
+    ) -> ElementCtx<'_, W, C::Element> {
         let style = self.create_styled::<C::Style>();
         let id =
             self.style_scoped(|ctx| composer.compose(style, ctx));
-        ElementHandle::new(&mut self.fynix.interactions, id)
+        ElementCtx::new(self.fynix, id)
     }
 
     /// Like [`Self::compose`], but runs `inline` after the style
@@ -99,12 +102,12 @@ impl<W> FynixCtx<'_, '_, W> {
         &mut self,
         composer: C,
         inline: impl FnOnce(&mut C::Style),
-    ) -> ElementHandle<'_> {
+    ) -> ElementCtx<'_, W, C::Element> {
         let mut style = self.create_styled::<C::Style>();
         inline(&mut style);
         let id =
             self.style_scoped(|ctx| composer.compose(style, ctx));
-        ElementHandle::new(&mut self.fynix.interactions, id)
+        ElementCtx::new(self.fynix, id)
     }
 
     /// Queues a style default: field `T` on type `S` will be set to
@@ -134,14 +137,14 @@ impl<W> FynixCtx<'_, '_, W> {
         &mut self,
         changed: ChangedFn<W>,
         build: BuildFn<W>,
-    ) -> ElementHandle<'_> {
+    ) -> ElementCtx<'_, W, ReactiveElement> {
         self.commit_pending_styles();
 
         // Build the holder element and its reactive together: the
         // element's id is needed to register the reactive, and the
         // reactive's id is needed to construct the element.
         let style_id = self.prev_style;
-        let element_id = self.fynix.elements.add_with_id(
+        let element_handle = self.fynix.elements.add_with_id(
             |element_id| {
                 self.fynix.reactives.add(Reactive::new(
                     changed, build, element_id, style_id,
@@ -150,6 +153,7 @@ impl<W> FynixCtx<'_, '_, W> {
             },
             None,
         );
+        let element_id = element_handle.as_id();
 
         // Build the initial subtree under the current style scope.
         let child = build(self);
@@ -170,7 +174,7 @@ impl<W> FynixCtx<'_, '_, W> {
             elem.child = child;
         }
 
-        ElementHandle::new(&mut self.fynix.interactions, element_id)
+        ElementCtx::new(self.fynix, element_handle)
     }
 
     /// Saves the current style scope, runs `scope`, then restores it.
@@ -232,23 +236,32 @@ impl<W> FynixCtx<'_, '_, W> {
     }
 }
 
-/// A freshly added element, borrowed for the length of one build
-/// statement so interaction handlers can be attached to it.
-///
-/// Returned by [`FynixCtx::add`]. Converts into the element's
-/// [`ElementId`] via [`Self::id`] or the [`From`]/[`Into`] impls, so
-/// it drops into any API that wants an id.
-pub struct ElementHandle<'a> {
-    interactions: &'a mut Interactions,
-    id: ElementId,
+pub struct ElementCtx<'f, W, E: Element> {
+    fynix: &'f mut Fynix<W>,
+    handle: ElementHandle<E>,
 }
 
-impl<'a> ElementHandle<'a> {
+impl<'f, W, E: Element> ElementCtx<'f, W, E> {
     fn new(
-        interactions: &'a mut Interactions,
-        id: ElementId,
+        fynix: &'f mut Fynix<W>,
+        handle: ElementHandle<E>,
     ) -> Self {
-        Self { interactions, id }
+        Self { fynix, handle }
+    }
+
+    pub fn bind<T>(
+        self,
+        changed_fn: binding::ChangedFn<W>,
+        get_fn: GetFn<W, T>,
+        mut_fn: MutFn<E, T>,
+    ) -> Self {
+        self.fynix.bindings.add(Binding::new(
+            changed_fn,
+            get_fn,
+            mut_fn,
+            self.id(),
+        ));
+        self
     }
 
     /// Attaches a handler for interaction type `I` to this element.
@@ -260,19 +273,30 @@ impl<'a> ElementHandle<'a> {
     /// The handler is a [`HandlerFn`], so a non-capturing closure
     /// coerces into one; a capturing closure does not.
     pub fn on<I: 'static>(self, handler: HandlerFn<I>) -> Self {
-        self.interactions.register::<I>(self.id, handler);
+        self.fynix.interactions.register::<I>(self.id(), handler);
         self
     }
 
-    /// Returns the element's id, ending the borrow of the context.
-    pub fn id(self) -> ElementId {
-        self.id
+    /// Returns the element's handle.
+    pub fn handle(&self) -> ElementHandle<E> {
+        self.handle
+    }
+
+    /// Returns the element's id.
+    pub fn id(&self) -> ElementId {
+        self.handle.as_id()
     }
 }
 
-impl From<ElementHandle<'_>> for ElementId {
-    fn from(handle: ElementHandle<'_>) -> Self {
-        handle.id
+impl<W, E: Element> From<ElementCtx<'_, W, E>> for ElementId {
+    fn from(ctx: ElementCtx<'_, W, E>) -> Self {
+        ctx.id()
+    }
+}
+
+impl<W, E: Element> From<ElementCtx<'_, W, E>> for ElementHandle<E> {
+    fn from(ctx: ElementCtx<'_, W, E>) -> Self {
+        ctx.handle()
     }
 }
 
@@ -580,16 +604,17 @@ mod tests {
 
     impl Composer<()> for LabelComposer {
         type Style = LabelStyle;
+        type Element = Label;
 
         fn compose(
             self,
             style: LabelStyle,
             ctx: &mut FynixCtx<'_, '_, ()>,
-        ) -> ElementId {
+        ) -> ElementHandle<Self::Element> {
             ctx.add_with::<Label>(|l, _| {
                 l.text = style.text;
             })
-            .id()
+            .handle()
         }
     }
 

--- a/crates/fynix/src/element/storage.rs
+++ b/crates/fynix/src/element/storage.rs
@@ -1,4 +1,5 @@
 use core::any::TypeId;
+use core::marker::PhantomData;
 
 use hashbrown::HashSet;
 use imaging::PaintSink;
@@ -56,7 +57,7 @@ impl Elements {
         &mut self,
         element: E,
         primary_style: Option<StyleId>,
-    ) -> ElementId {
+    ) -> ElementHandle<E> {
         self.add_with_id(
             #[inline(always)]
             |_| element,
@@ -75,7 +76,7 @@ impl Elements {
         &mut self,
         create: impl FnOnce(ElementId) -> E,
         primary_style: Option<StyleId>,
-    ) -> ElementId {
+    ) -> ElementHandle<E> {
         let col = self.elements.ensure_column::<E>();
         self.type_metas.register::<E>(col);
 
@@ -95,7 +96,7 @@ impl Elements {
 
         let id = ElementId(key);
         self.mark_dirty(id);
-        id
+        ElementHandle::new(id)
     }
 
     /// Returns a type-erased reference to the element.
@@ -293,6 +294,39 @@ impl Elements {
 impl Default for Elements {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[derive(Debug)]
+pub struct ElementHandle<E: Element> {
+    id: ElementId,
+    _marker: PhantomData<fn() -> E>,
+}
+
+impl<E: Element> ElementHandle<E> {
+    pub fn new(id: ElementId) -> Self {
+        Self {
+            id,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn as_id(self) -> ElementId {
+        self.id
+    }
+}
+
+impl<E: Element> Copy for ElementHandle<E> {}
+
+impl<E: Element> Clone for ElementHandle<E> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<E: Element> From<ElementHandle<E>> for ElementId {
+    fn from(value: ElementHandle<E>) -> Self {
+        value.id
     }
 }
 

--- a/crates/fynix/src/element/storage.rs
+++ b/crates/fynix/src/element/storage.rs
@@ -297,6 +297,12 @@ impl Default for Elements {
     }
 }
 
+/// A typed, [`Copy`] reference to a stored element: an [`ElementId`]
+/// tagged with its element type `E`.
+///
+/// The type tag is what lets `bind` type-check a field accessor
+/// against the element it targets. The `fn() -> E` marker keeps the
+/// handle neutral on variance and auto traits while owning no `E`.
 #[derive(Debug)]
 pub struct ElementHandle<E: Element> {
     id: ElementId,
@@ -304,6 +310,7 @@ pub struct ElementHandle<E: Element> {
 }
 
 impl<E: Element> ElementHandle<E> {
+    /// Tags `id` with the element type `E`.
     pub fn new(id: ElementId) -> Self {
         Self {
             id,
@@ -311,6 +318,7 @@ impl<E: Element> ElementHandle<E> {
         }
     }
 
+    /// Drops the type tag, returning the bare [`ElementId`].
     pub fn as_id(self) -> ElementId {
         self.id
     }

--- a/crates/fynix/src/interaction.rs
+++ b/crates/fynix/src/interaction.rs
@@ -7,19 +7,19 @@ use crate::element::ElementId;
 /// emitting messages into [`Events`].
 ///
 /// A plain function pointer, so a non-capturing closure coerces into
-/// one at the [`on`](crate::ctx::ElementHandle::on) call site.
+/// one at the [`on`](crate::ctx::ElementCtx::on) call site.
 pub type HandlerFn<I> = fn(I, &mut Events);
 
 /// Per-instance interaction store.
 ///
 /// Each element instance carries its own handlers, attached at build
-/// time via [`FynixCtx::add`] and [`ElementHandle::on`]. The
+/// time via [`FynixCtx::add`] and [`ElementCtx::on`]. The
 /// [`TypeTable`] keeps one column of [`HandlerFn<I>`] per interaction
 /// type `I`, addressed by [`ElementId`], so dispatching `I` to an id
 /// is a single typed column lookup.
 ///
 /// [`FynixCtx::add`]: crate::ctx::FynixCtx::add
-/// [`ElementHandle::on`]: crate::ctx::ElementHandle::on
+/// [`ElementCtx::on`]: crate::ctx::ElementCtx::on
 pub struct Interactions {
     table: TypeTable<ElementId>,
 }

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -8,6 +8,7 @@ use fynix_event::Events;
 pub use imaging;
 use imaging::PaintSink;
 
+use crate::binding::Bindings;
 use crate::ctx::FynixCtx;
 use crate::element::{ElementId, Elements};
 use crate::interaction::Interactions;
@@ -15,6 +16,7 @@ use crate::reactive::{ReactiveElement, Reactives};
 use crate::resource::Resources;
 use crate::style::{StyleId, Styles};
 
+pub mod binding;
 pub mod composer;
 pub mod ctx;
 pub mod element;
@@ -52,6 +54,7 @@ pub struct Fynix<W> {
     elements: Elements,
     styles: Styles,
     reactives: Reactives<W>,
+    bindings: Bindings<W>,
     events: Events,
     interactions: Interactions,
 }
@@ -63,6 +66,7 @@ impl<W> Fynix<W> {
             elements: Elements::new(),
             styles: Styles::new(),
             reactives: Reactives::new(),
+            bindings: Bindings::new(),
             events: Events::new(),
             interactions: Interactions::new(),
         }
@@ -127,6 +131,7 @@ impl<W> Fynix<W> {
             // Drop any reactive and interaction handlers this
             // element owns.
             self.reactives.remove_for_element(id);
+            self.bindings.remove_for_element(id);
             self.interactions.remove(id);
         })
     }
@@ -179,6 +184,10 @@ impl<W> Fynix<W> {
             // Mark the rebuilt subtree dirty so it is re-laid-out
             // and re-rendered.
             self.elements.mark_dirty(element_id);
+        }
+
+        for binding in self.bindings.snapshot_changed(world) {
+            binding.apply(&mut self.elements, world);
         }
     }
 

--- a/crates/fynix/src/reactive.rs
+++ b/crates/fynix/src/reactive.rs
@@ -18,21 +18,21 @@ pub struct Reactives<W> {
     reactives: SparseMap<Reactive<W>>,
     /// Reverse index from each holder element to its reactive, used
     /// to remove the reactive when the element is removed.
-    by_element: HashMap<ElementId, ReactiveId>,
+    element_map: HashMap<ElementId, ReactiveId>,
 }
 
 impl<W> Reactives<W> {
     pub fn new() -> Self {
         Self {
             reactives: SparseMap::new(),
-            by_element: HashMap::new(),
+            element_map: HashMap::new(),
         }
     }
 
     pub fn add(&mut self, reactive: Reactive<W>) -> ReactiveId {
         let element_id = reactive.element_id;
         let reactive_id = ReactiveId(self.reactives.insert(reactive));
-        self.by_element.insert(element_id, reactive_id);
+        self.element_map.insert(element_id, reactive_id);
         reactive_id
     }
 
@@ -43,7 +43,7 @@ impl<W> Reactives<W> {
         &mut self,
         element_id: &ElementId,
     ) {
-        if let Some(reactive_id) = self.by_element.remove(element_id)
+        if let Some(reactive_id) = self.element_map.remove(element_id)
         {
             self.reactives.remove(&reactive_id.0);
         }

--- a/examples/vello_winit_examples/examples/hello_world.rs
+++ b/examples/vello_winit_examples/examples/hello_world.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use fynix::element::storage::ElementHandle;
 use fynix::prelude::*;
 use fynix_elements::parley::FontStyle;
 use fynix_elements::parley::fontique::{Blob, GenericFamily};
@@ -26,21 +27,17 @@ fn main_layout(ctx: &mut FynixCtx<HelloWorld>) -> ElementId {
         p.set_child(ctx.add_with::<Vertical>(|v, ctx| {
             ctx.set(path!(<Label>::fill), css::WHITE_SMOKE.into());
 
-            // Reactive FPS counter: rebuilt only when the value
-            // changes (see `DemoWorld::update`).
-            v.add(ctx.reactive(
-                |w| w.fps_changed,
-                |ctx| {
-                    let fps = ctx.world.fps;
-                    Some(
-                        ctx.add_with::<Label>(|label, _| {
-                            label.text = format!("FPS: {fps}");
-                            label.font_size = 20.0;
-                        })
-                        .id(),
-                    )
-                },
-            ));
+            v.add(
+                ctx.add_with::<Label>(|label, ctx| {
+                    label.text = format!("FPS: {}", ctx.world.fps);
+                    label.font_size = 20.0;
+                })
+                .bind(
+                    |w| w.fps_changed,
+                    |w| format!("FPS: {}", w.fps),
+                    |label| &mut label.text,
+                ),
+            );
 
             v.add(ctx.add_with::<Label>(|label, _ctx| {
                 label.text = "Hello, Fynix!".into();
@@ -96,14 +93,13 @@ fn main_layout(ctx: &mut FynixCtx<HelloWorld>) -> ElementId {
 /// frame delta, plus the latest window size.
 #[derive(Default)]
 struct HelloWorld {
+    /// The current fps of the app.
     fps: u32,
-    /// True only on the frame `fps` changed, so the reactive counter
-    /// rebuilds just then.
+    /// True only on the frame `fps` changed.
     fps_changed: bool,
     /// Latest window size pushed in by the backend.
     window_size: Size,
-    /// True when `window_size` changed, so the reactive window
-    /// subtree rebuilds just then.
+    /// True when `window_size` changed.
     window_size_changed: bool,
 }
 
@@ -145,21 +141,16 @@ impl DemoWorld for HelloWorld {
     }
 
     fn build(ctx: &mut FynixCtx<Self>) -> ElementId {
-        // Reactive window subtree: rebuilt only when the window size
-        // changes (see `set_window_size`).
-        ctx.reactive(
+        let size = ctx.world.window_size;
+        ctx.world.window_size_changed = false;
+        ctx.add_with::<WindowSize>(|win, ctx| {
+            win.size = size;
+            win.set_child(main_layout(ctx));
+        })
+        .bind(
             |w| w.window_size_changed,
-            |ctx| {
-                let size = ctx.world.window_size;
-                ctx.world.window_size_changed = false;
-                Some(
-                    ctx.add_with::<WindowSize>(|win, ctx| {
-                        win.size = size;
-                        win.set_child(main_layout(ctx));
-                    })
-                    .id(),
-                )
-            },
+            |w| w.window_size,
+            |win| &mut win.size,
         )
         .id()
     }
@@ -182,12 +173,13 @@ struct TextButton<'a> {
 
 impl Composer<HelloWorld> for TextButton<'_> {
     type Style = TextButtonStyle;
+    type Element = Button;
 
     fn compose(
         self,
         style: TextButtonStyle,
         ctx: &mut FynixCtx<'_, '_, HelloWorld>,
-    ) -> ElementId {
+    ) -> ElementHandle<Self::Element> {
         ctx.add_with::<Button>(|b, ctx| {
             b.corner_radius = style.corner_radius;
             if let Some(bg_color) = style.bg_color {
@@ -201,6 +193,6 @@ impl Composer<HelloWorld> for TextButton<'_> {
                 }));
             }));
         })
-        .id()
+        .handle()
     }
 }

--- a/examples/vello_winit_examples/src/lib.rs
+++ b/examples/vello_winit_examples/src/lib.rs
@@ -259,11 +259,7 @@ impl<D: DemoWorld> ApplicationHandler for VelloWinitApp<'_, D> {
                 let size =
                     Size::new(phys.width as f32, phys.height as f32);
                 self.world.set_window_size(size);
-                if let RenderState::Active { window, .. } =
-                    &self.state
-                {
-                    window.request_redraw();
-                }
+                self.render();
             }
             _ => {}
         }


### PR DESCRIPTION
Unlike a reactive (which allows you to mutate an entire subtree), a binding allows you to only mutate a single element.

The example now uses binding instead of reactive to reduce unnecessary computation.