### PR TITLE
Decouple interaction events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,12 +592,10 @@ name = "fynix"
 version = "0.1.0"
 dependencies = [
  "field_path",
- "fynix_event",
  "fynix_macros",
  "hashbrown 0.16.1",
  "imaging",
  "rectree",
- "sparse_map",
  "typarena",
 ]
 

--- a/crates/fynix/Cargo.toml
+++ b/crates/fynix/Cargo.toml
@@ -10,11 +10,9 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-fynix_event.workspace = true
 fynix_macros.workspace = true
 typarena.workspace = true
 rectree.workspace = true
-sparse_map.workspace = true
 hashbrown.workspace = true
 field_path.workspace = true
 imaging.workspace = true

--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -9,7 +9,7 @@ use crate::init::Init;
 use crate::interaction::HandlerFn;
 use crate::reactive::ChangedFn;
 use crate::reactive::binding::{Binding, GetFn};
-use crate::reactive::watch::{BuildFn, Watch, WatchElement};
+use crate::reactive::watcher::{BuildFn, Watcher, WatcherElement};
 use crate::style::{Stylable, StyleId, StyleValue};
 
 /// Build-time context for constructing the element tree and declaring
@@ -28,7 +28,7 @@ use crate::style::{Stylable, StyleId, StyleValue};
 /// leak outward.
 ///
 /// [`Style`]: crate::style::Style
-pub struct FynixCtx<'f, 'w, W> {
+pub struct FynixCtx<'f, 'w, W: 'static> {
     fynix: &'f mut Fynix<W>,
     pub world: &'w mut W,
 
@@ -120,7 +120,7 @@ impl<W> FynixCtx<'_, '_, W> {
         self.fynix.styles.set(field_accessor, value);
     }
 
-    /// Attaches a watch to the element tree.
+    /// Attaches a watcher to the element tree.
     ///
     /// `build` constructs a subtree and `changed` reports whether the
     /// state it reads has changed since the last build. When
@@ -128,7 +128,7 @@ impl<W> FynixCtx<'_, '_, W> {
     /// place.
     ///
     /// The initial subtree is built immediately, under the current
-    /// style scope. That scope is captured on the [`Watch`] and
+    /// style scope. That scope is captured on the [`Watcher`] and
     /// restored on every rebuild, so a rebuilt subtree is styled like
     /// the first.
     #[must_use]
@@ -136,21 +136,18 @@ impl<W> FynixCtx<'_, '_, W> {
         &mut self,
         changed: ChangedFn<W>,
         build: BuildFn<W>,
-    ) -> ElementCtx<'_, W, WatchElement>
-    where
-        W: 'static,
-    {
+    ) -> ElementCtx<'_, W, WatcherElement> {
         self.commit_pending_styles();
 
-        // Build the holder element, then attach the watch as a
+        // Build the holder element, then attach the watcher as a
         // component keyed by the holder's id.
         let style_id = self.prev_style;
         let element_handle =
-            self.fynix.elements.add(WatchElement::init(), None);
+            self.fynix.elements.add(WatcherElement::init(), None);
         let element_id = element_handle.as_id();
-        self.fynix.elements.table.insert_component(
+        self.fynix.elements.table.insert_watcher(
             element_id,
-            Watch::new(changed, build, style_id),
+            Watcher::new(changed, build, style_id),
         );
 
         // Build the initial subtree under the current style scope.
@@ -167,7 +164,7 @@ impl<W> FynixCtx<'_, '_, W> {
         if let Some(elem) = self
             .fynix
             .elements
-            .get_typed_mut::<WatchElement>(&element_id)
+            .get_typed_mut::<WatcherElement>(&element_id)
         {
             elem.child = child;
         }
@@ -240,7 +237,7 @@ impl<W> FynixCtx<'_, '_, W> {
 ///
 /// Carries `E` so configuration can be type-checked against the
 /// element. Converts into its [`ElementId`] or [`ElementHandle`].
-pub struct ElementCtx<'f, W, E: Element> {
+pub struct ElementCtx<'f, W: 'static, E: Element> {
     fynix: &'f mut Fynix<W>,
     handle: ElementHandle<E>,
 }
@@ -257,7 +254,7 @@ impl<'f, W, E: Element> ElementCtx<'f, W, E> {
     ///
     /// When `changed_fn` reports a change, `get_fn` reads the new
     /// value from the world and it is written through `mut_fn` into
-    /// this element, which is then marked dirty. Unlike a watch,
+    /// this element, which is then marked dirty. Unlike a watcher,
     /// nothing is rebuilt: only the field is updated in place.
     ///
     /// Chainable, and applied each frame by
@@ -267,12 +264,9 @@ impl<'f, W, E: Element> ElementCtx<'f, W, E> {
         changed_fn: ChangedFn<W>,
         get_fn: GetFn<W, T>,
         mut_fn: MutFn<E, T>,
-    ) -> Self
-    where
-        W: 'static,
-    {
+    ) -> Self {
         let id = self.id();
-        self.fynix.elements.table.insert_component(
+        self.fynix.elements.table.insert_binding(
             id,
             Binding::new(changed_fn, get_fn, mut_fn),
         );
@@ -287,10 +281,7 @@ impl<'f, W, E: Element> ElementCtx<'f, W, E> {
     ///
     /// The handler is a [`HandlerFn`], so a non-capturing closure
     /// coerces into one; a capturing closure does not.
-    pub fn on<I: 'static>(self, handler: HandlerFn<I, W>) -> Self
-    where
-        W: 'static,
-    {
+    pub fn on<I: 'static>(self, handler: HandlerFn<I, W>) -> Self {
         self.fynix
             .elements
             .table

--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -287,8 +287,14 @@ impl<'f, W, E: Element> ElementCtx<'f, W, E> {
     ///
     /// The handler is a [`HandlerFn`], so a non-capturing closure
     /// coerces into one; a capturing closure does not.
-    pub fn on<I: 'static>(self, handler: HandlerFn<I>) -> Self {
-        self.fynix.interactions.register::<I>(self.id(), handler);
+    pub fn on<I: 'static>(self, handler: HandlerFn<I, W>) -> Self
+    where
+        W: 'static,
+    {
+        self.fynix
+            .elements
+            .table
+            .insert_component::<HandlerFn<I, W>>(self.id(), handler);
         self
     }
 

--- a/crates/fynix/src/element.rs
+++ b/crates/fynix/src/element.rs
@@ -2,7 +2,7 @@ use imaging::PaintSink;
 use rectree::{Constraint, Size};
 
 use crate::element::layout::ElementNodes;
-use crate::element::table::ElementTable;
+use crate::element::table::RenderElementTable;
 use crate::init::Init;
 
 pub mod layout;
@@ -83,7 +83,7 @@ pub trait ElementBuild {
         &self,
         id: &ElementId,
         painter: &mut dyn PaintSink,
-        table: &ElementTable,
+        table: RenderElementTable,
     ) {
     }
 }

--- a/crates/fynix/src/element/layout.rs
+++ b/crates/fynix/src/element/layout.rs
@@ -3,7 +3,7 @@ use rectree::{Constraint, RectNode, RectNodes, Rectree, Size};
 use typarena::type_pool::TypePool;
 
 use crate::element::ElementId;
-use crate::element::table::ElementTable;
+use crate::element::table::LayoutElementTable;
 use crate::element::type_meta::ElementTypeMetas;
 use crate::resource::Resources;
 
@@ -68,7 +68,7 @@ impl<'a> Rectree for ElementTree<'a> {
 }
 
 pub struct ElementNodes<'a> {
-    pub(crate) table: &'a mut ElementTable,
+    pub(crate) table: LayoutElementTable<'a>,
     pub(crate) resources: &'a mut Resources,
 }
 

--- a/crates/fynix/src/element/storage.rs
+++ b/crates/fynix/src/element/storage.rs
@@ -16,18 +16,18 @@ use crate::style::StyleId;
 ///
 /// Internally holds one column per element type inside a
 /// [`TypePool`].
-pub struct Elements {
+pub struct Elements<W: 'static> {
     // TODO(nixon): Make these private and provide a more
     // elegant API!
     pub elements: TypePool,
-    pub table: ElementTable,
+    pub table: ElementTable<W>,
     pub type_metas: ElementTypeMetas,
     /// Elements whose subtree changed and needs re-layout/render,
-    /// e.g. after a watch rebuilt its child.
+    /// e.g. after a watcher rebuilt its child.
     pub dirty_elements: HashSet<ElementId>,
 }
 
-impl Elements {
+impl<W> Elements<W> {
     pub fn new() -> Self {
         Self {
             elements: TypePool::new(),
@@ -149,9 +149,9 @@ impl Elements {
         id: &ElementId,
         mut on_removed: impl FnMut(&ElementId, Option<StyleId>),
     ) -> bool {
-        fn remove_recursive(
+        fn remove_recursive<W: 'static>(
             id: &ElementId,
-            table: &mut ElementTable,
+            table: &mut ElementTable<W>,
             type_metas: &ElementTypeMetas,
             elements: &mut TypePool,
             on_removed: &mut impl FnMut(&ElementId, Option<StyleId>),
@@ -221,7 +221,11 @@ impl Elements {
             if let Some(element) =
                 type_meta.get_dyn(&self.elements, id)
             {
-                element.render(id, painter, &self.table);
+                element.render(
+                    id,
+                    painter,
+                    self.table.render_table(),
+                );
             }
             type_meta.for_each_child(
                 &self.elements,
@@ -279,7 +283,7 @@ impl Elements {
         };
 
         let mut nodes = ElementNodes {
-            table: &mut self.table,
+            table: self.table.layout_table(),
             resources,
         };
 
@@ -291,7 +295,7 @@ impl Elements {
     }
 }
 
-impl Default for Elements {
+impl<W> Default for Elements<W> {
     fn default() -> Self {
         Self::new()
     }

--- a/crates/fynix/src/element/table.rs
+++ b/crates/fynix/src/element/table.rs
@@ -229,7 +229,9 @@ mod tests {
 
     #[test]
     fn component_round_trips_and_is_dropped_on_remove() {
-        let (id, other) = two_ids();
+        let mut generator = IdGenerator::default();
+        let id = generator.generate();
+        let other = generator.generate();
         let mut table = ElementTable::new();
         table.init_element(id, None);
         table.init_element(other, None);

--- a/crates/fynix/src/element/table.rs
+++ b/crates/fynix/src/element/table.rs
@@ -160,15 +160,20 @@ mod tests {
     use crate::element::ElementId;
     use crate::style::StyleIdGenerator;
 
-    /// Mints two distinct element ids via a throwaway pool.
-    fn two_ids() -> (ElementId, ElementId) {
-        let mut pool = TypePool::new();
-        (ElementId(pool.insert(0u8)), ElementId(pool.insert(1u8)))
+    #[derive(Default)]
+    struct IdGenerator {
+        pool: TypePool,
+    }
+
+    impl IdGenerator {
+        fn generate(&mut self) -> ElementId {
+            ElementId(self.pool.insert(1))
+        }
     }
 
     #[test]
     fn init_seeds_node_and_primary_style() {
-        let (id, _) = two_ids();
+        let id = IdGenerator::default().generate();
         let style = StyleIdGenerator::new().new_id();
         let mut table = ElementTable::new();
         table.init_element(id, Some(style));
@@ -181,7 +186,7 @@ mod tests {
 
     #[test]
     fn init_without_primary_style_leaves_it_absent() {
-        let (id, _) = two_ids();
+        let id = IdGenerator::default().generate();
         let mut table = ElementTable::new();
         table.init_element(id, None);
 
@@ -191,7 +196,7 @@ mod tests {
 
     #[test]
     fn set_scene_round_trips() {
-        let (id, _) = two_ids();
+        let id = IdGenerator::default().generate();
         let mut table = ElementTable::new();
         table.init_element(id, None);
 
@@ -202,21 +207,24 @@ mod tests {
 
     #[test]
     fn remove_drops_every_column() {
-        let (id, other) = two_ids();
+        let mut generator = IdGenerator::default();
+        let id0 = generator.generate();
+        let id1 = generator.generate();
+
         let style = StyleIdGenerator::new().new_id();
         let mut table = ElementTable::new();
-        table.init_element(id, Some(style));
-        table.init_element(other, None);
-        table.set_scene(&id, Scene::new());
+        table.init_element(id0, Some(style));
+        table.init_element(id1, None);
+        table.set_scene(&id0, Scene::new());
 
-        assert!(table.remove(&id));
-        assert!(table.node(&id).is_none());
-        assert!(table.scene(&id).is_none());
-        assert_eq!(table.primary_style(&id), None);
+        assert!(table.remove(&id0));
+        assert!(table.node(&id0).is_none());
+        assert!(table.scene(&id0).is_none());
+        assert_eq!(table.primary_style(&id0), None);
         // A second removal finds nothing left.
-        assert!(!table.remove(&id));
+        assert!(!table.remove(&id0));
         // Sibling metadata is untouched.
-        assert!(table.node(&other).is_some());
+        assert!(table.node(&id1).is_some());
     }
 
     #[test]

--- a/crates/fynix/src/element/table.rs
+++ b/crates/fynix/src/element/table.rs
@@ -1,39 +1,48 @@
+use core::marker::PhantomData;
+
 use imaging::record::Scene;
 use typarena::ColumnId;
 use typarena::type_table::TypeTable;
 
 use crate::element::ElementId;
 use crate::element::layout::ElementNode;
+use crate::reactive::binding::Binding;
+use crate::reactive::watcher::Watcher;
 use crate::style::StyleId;
 
-/// Per-element metadata storage, keyed by [`ElementId`].
+/// Per-element component storage, keyed by [`ElementId`].
 ///
-/// Each metadata field lives in its own [`TypeTable`] column
-/// (struct-of-arrays). The layout node is dense, one per element,
-/// while the cached scene and primary style are sparse, present only
-/// when set.
-///
-/// The three columns are created up front and their [`ColumnId`]s
-/// cached, so every accessor reaches its column by index and skips
-/// the per-call [`TypeId`](core::any::TypeId) hash lookup.
-pub struct ElementTable {
+/// Each component field lives in its own [`TypeTable`] column
+/// (struct-of-arrays).
+pub struct ElementTable<W: 'static> {
     table: TypeTable<ElementId>,
     node_col: ColumnId,
     scene_col: ColumnId,
     style_col: ColumnId,
+    watch_col: ColumnId,
+    binding_col: ColumnId,
+    _world_marker: PhantomData<fn() -> W>,
 }
 
-impl ElementTable {
+impl<W> ElementTable<W> {
     pub fn new() -> Self {
         let mut table = TypeTable::new();
+
+        // Store column ids for fast access.
         let node_col = table.ensure_column::<ElementNode>();
         let scene_col = table.ensure_column::<Scene>();
         let style_col = table.ensure_column::<StyleId>();
+        let watch_col = table.ensure_column::<Watcher<W>>();
+        let binding_col = table.ensure_column::<Binding<W>>();
+
         Self {
             table,
             node_col,
             scene_col,
             style_col,
+            watch_col,
+            binding_col,
+            _world_marker: PhantomData,
         }
     }
 
@@ -53,11 +62,32 @@ impl ElementTable {
             self.table.insert_by_column(id, style, self.style_col);
         }
     }
+}
 
+/// Rendering & layouting.
+impl<W> ElementTable<W> {
     /// Drops every metadata column for `id`. Returns `true` if any
     /// column held it.
     pub(super) fn remove(&mut self, id: &ElementId) -> bool {
         self.table.remove_row(id)
+    }
+
+    /// Creates a [`RenderElementTable`].
+    pub fn render_table(&self) -> RenderElementTable<'_> {
+        RenderElementTable {
+            table: &self.table,
+            node_col: self.node_col,
+            scene_col: self.scene_col,
+        }
+    }
+
+    /// Creates a [`LayoutElementTable`].
+    pub fn layout_table(&mut self) -> LayoutElementTable<'_> {
+        LayoutElementTable {
+            table: &mut self.table,
+            node_col: self.node_col,
+            scene_col: self.scene_col,
+        }
     }
 
     /// Returns the layout node for `id`, if present.
@@ -79,8 +109,8 @@ impl ElementTable {
     }
 
     /// Caches `scene` for `id`.
-    pub fn set_scene(&mut self, id: &ElementId, scene: Scene) {
-        self.table.insert_by_column(*id, scene, self.scene_col);
+    pub fn set_scene(&mut self, id: ElementId, scene: Scene) {
+        self.table.insert_by_column(id, scene, self.scene_col);
     }
 
     /// Returns the `primary_style` recorded for `id`, if any.
@@ -94,14 +124,27 @@ impl ElementTable {
     }
 }
 
+/// Reactive.
+impl<W> ElementTable<W> {
+    pub fn insert_watcher(
+        &mut self,
+        id: ElementId,
+        watch: Watcher<W>,
+    ) -> Option<Watcher<W>> {
+        self.table.insert_by_column(id, watch, self.watch_col)
+    }
+
+    pub fn insert_binding(
+        &mut self,
+        id: ElementId,
+        binding: Binding<W>,
+    ) -> Option<Binding<W>> {
+        self.table.insert_by_column(id, binding, self.binding_col)
+    }
+}
+
 /// Arbitrary per-element components.
-///
-/// Beyond the fixed node, scene, and style columns, an element can
-/// carry at most one value of any other type `T`, stored in a column
-/// created on first insert. Used for the at-most-one-per-element data
-/// such as a watch or a field binding. Components are
-/// dropped with the element when its row is removed.
-impl ElementTable {
+impl<W> ElementTable<W> {
     /// Attaches `value` to `id`, replacing any previous component of
     /// type `T`. Returns the replaced value, if any.
     pub fn insert_component<T: 'static>(
@@ -146,9 +189,58 @@ impl ElementTable {
     }
 }
 
-impl Default for ElementTable {
+impl<W> Default for ElementTable<W> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+pub struct RenderElementTable<'a> {
+    table: &'a TypeTable<ElementId>,
+    node_col: ColumnId,
+    scene_col: ColumnId,
+}
+
+impl RenderElementTable<'_> {
+    /// Returns the layout node for `id`, if present.
+    pub fn node(&self, id: &ElementId) -> Option<&ElementNode> {
+        self.table.get_by_column(self.node_col, id)
+    }
+
+    /// Returns the cached scene for `id`, if one has been stored.
+    pub fn scene(&self, id: &ElementId) -> Option<&Scene> {
+        self.table.get_by_column(self.scene_col, id)
+    }
+}
+
+pub struct LayoutElementTable<'a> {
+    table: &'a mut TypeTable<ElementId>,
+    node_col: ColumnId,
+    scene_col: ColumnId,
+}
+
+impl LayoutElementTable<'_> {
+    /// Returns the layout node for `id`, if present.
+    pub fn node(&self, id: &ElementId) -> Option<&ElementNode> {
+        self.table.get_by_column(self.node_col, id)
+    }
+
+    /// Returns a mutable reference to the layout node for `id`.
+    pub fn node_mut(
+        &mut self,
+        id: &ElementId,
+    ) -> Option<&mut ElementNode> {
+        self.table.get_mut_by_column(self.node_col, id)
+    }
+
+    /// Returns the cached scene for `id`, if one has been stored.
+    pub fn scene(&self, id: &ElementId) -> Option<&Scene> {
+        self.table.get_by_column(self.scene_col, id)
+    }
+
+    /// Caches `scene` for `id`.
+    pub fn set_scene(&mut self, id: &ElementId, scene: Scene) {
+        self.table.insert_by_column(*id, scene, self.scene_col);
     }
 }
 
@@ -171,11 +263,13 @@ mod tests {
         }
     }
 
+    type TestElementTable = ElementTable<()>;
+
     #[test]
     fn init_seeds_node_and_primary_style() {
         let id = IdGenerator::default().generate();
         let style = StyleIdGenerator::new().new_id();
-        let mut table = ElementTable::new();
+        let mut table = TestElementTable::new();
         table.init_element(id, Some(style));
 
         assert!(table.node(&id).is_some());
@@ -187,7 +281,7 @@ mod tests {
     #[test]
     fn init_without_primary_style_leaves_it_absent() {
         let id = IdGenerator::default().generate();
-        let mut table = ElementTable::new();
+        let mut table = TestElementTable::new();
         table.init_element(id, None);
 
         assert!(table.node(&id).is_some());
@@ -197,11 +291,11 @@ mod tests {
     #[test]
     fn set_scene_round_trips() {
         let id = IdGenerator::default().generate();
-        let mut table = ElementTable::new();
+        let mut table = TestElementTable::new();
         table.init_element(id, None);
 
         assert!(table.scene(&id).is_none());
-        table.set_scene(&id, Scene::new());
+        table.set_scene(id, Scene::new());
         assert_eq!(table.scene(&id), Some(&Scene::new()));
     }
 
@@ -212,10 +306,10 @@ mod tests {
         let id1 = generator.generate();
 
         let style = StyleIdGenerator::new().new_id();
-        let mut table = ElementTable::new();
+        let mut table = TestElementTable::new();
         table.init_element(id0, Some(style));
         table.init_element(id1, None);
-        table.set_scene(&id0, Scene::new());
+        table.set_scene(id0, Scene::new());
 
         assert!(table.remove(&id0));
         assert!(table.node(&id0).is_none());
@@ -232,7 +326,7 @@ mod tests {
         let mut generator = IdGenerator::default();
         let id = generator.generate();
         let other = generator.generate();
-        let mut table = ElementTable::new();
+        let mut table = TestElementTable::new();
         table.init_element(id, None);
         table.init_element(other, None);
 

--- a/crates/fynix/src/interaction.rs
+++ b/crates/fynix/src/interaction.rs
@@ -1,85 +1,19 @@
-use fynix_event::Events;
-use typarena::type_table::TypeTable;
-
-use crate::element::ElementId;
-
-/// User-written interaction handler: reacts to interaction `I`,
-/// emitting messages into [`Events`].
+/// User-written interaction handler: reacts to interaction `I` by
+/// mutating the world `W`.
 ///
 /// A plain function pointer, so a non-capturing closure coerces into
-/// one at the [`on`](crate::ctx::ElementCtx::on) call site.
-pub type HandlerFn<I> = fn(I, &mut Events);
-
-/// Per-instance interaction store.
-///
-/// Each element instance carries its own handlers, attached at build
-/// time via [`FynixCtx::add`] and [`ElementCtx::on`]. The
-/// [`TypeTable`] keeps one column of [`HandlerFn<I>`] per interaction
-/// type `I`, addressed by [`ElementId`], so dispatching `I` to an id
-/// is a single typed column lookup.
-///
-/// [`FynixCtx::add`]: crate::ctx::FynixCtx::add
-/// [`ElementCtx::on`]: crate::ctx::ElementCtx::on
-pub struct Interactions {
-    table: TypeTable<ElementId>,
-}
-
-impl Interactions {
-    /// Creates an empty store.
-    pub fn new() -> Self {
-        Self {
-            table: TypeTable::new(),
-        }
-    }
-
-    /// Attaches `handler` to `id` for interaction type `I`.
-    ///
-    /// Replaces any handler previously attached to `id` for `I`.
-    pub fn register<I: 'static>(
-        &mut self,
-        id: ElementId,
-        handler: HandlerFn<I>,
-    ) {
-        self.table.insert(id, handler);
-    }
-
-    /// Drops every handler attached to `id`, across all interaction
-    /// types. Returns `true` if any were present.
-    pub fn remove(&mut self, id: &ElementId) -> bool {
-        self.table.remove_row(id)
-    }
-
-    /// Runs the handler attached to `id` for interaction `I`, if one
-    /// exists. Returns `true` if a handler ran.
-    pub fn dispatch<I: 'static>(
-        &self,
-        id: &ElementId,
-        interaction: I,
-        events: &mut Events,
-    ) -> bool {
-        if let Some(handler) = self.table.get::<HandlerFn<I>>(id) {
-            handler(interaction, events);
-            return true;
-        }
-
-        false
-    }
-}
-
-impl Default for Interactions {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+/// one at the [`on`](crate::ctx::ElementCtx::on) call site. Stored
+/// per instance as an element-table component, one per `(element,
+/// I)`.
+pub type HandlerFn<I, W> = fn(I, &mut W);
 
 #[cfg(test)]
 mod tests {
     use rectree::{Constraint, Size};
 
-    use super::*;
     use crate::Fynix;
     use crate::element::layout::ElementNodes;
-    use crate::element::{Element, ElementBuild};
+    use crate::element::{Element, ElementBuild, ElementId};
     use crate::init::Init;
 
     #[derive(Init, Element)]
@@ -98,34 +32,31 @@ mod tests {
 
     struct Click;
 
-    #[derive(Debug, PartialEq)]
-    struct Clicked(u32);
+    #[derive(Default)]
+    struct World {
+        clicks: u32,
+    }
 
     #[test]
     fn dispatch_runs_attached_handler() {
-        let mut world = ();
+        let mut world = World::default();
         let mut fynix = Fynix::new();
         let id = {
             let mut ctx = fynix.root_ctx(&mut world);
             ctx.add::<Button>()
-                .on::<Click>(|_, events| {
-                    events.push(Clicked(1));
-                })
+                .on::<Click>(|_, world| world.clicks += 1)
                 .id()
         };
 
-        let ran = fynix.dispatch(&id, Click);
+        let ran = fynix.dispatch(&id, Click, &mut world);
 
         assert!(ran);
-        assert_eq!(
-            fynix.events.iter::<Clicked>().next(),
-            Some(&Clicked(1))
-        );
+        assert_eq!(world.clicks, 1);
     }
 
     #[test]
     fn dispatch_without_handler_returns_false() {
-        let mut world = ();
+        let mut world = World::default();
         let mut fynix = Fynix::new();
         let id = {
             let mut ctx = fynix.root_ctx(&mut world);
@@ -133,43 +64,45 @@ mod tests {
         };
 
         struct Unhandled;
-        let ran = fynix.dispatch(&id, Unhandled);
+        let ran = fynix.dispatch(&id, Unhandled, &mut world);
 
         assert!(!ran);
     }
 
     #[test]
     fn handlers_are_per_instance() {
-        let mut world = ();
+        let mut world = World::default();
         let mut fynix = Fynix::new();
         let (handled, plain) = {
             let mut ctx = fynix.root_ctx(&mut world);
             let handled = ctx
                 .add::<Button>()
-                .on::<Click>(|_, events| events.push(Clicked(1)))
+                .on::<Click>(|_, world| world.clicks += 1)
                 .id();
             // A second instance of the same type with no handler.
             let plain = ctx.add::<Button>().id();
             (handled, plain)
         };
 
-        assert!(fynix.dispatch(&handled, Click));
-        assert!(!fynix.dispatch(&plain, Click));
-        assert_eq!(fynix.events.iter::<Clicked>().count(), 1);
+        assert!(fynix.dispatch(&handled, Click, &mut world));
+        assert!(!fynix.dispatch(&plain, Click, &mut world));
+        assert_eq!(world.clicks, 1);
     }
 
     #[test]
-    fn remove_drops_handlers() {
-        let mut world = ();
+    fn removing_element_drops_handlers() {
+        let mut world = World::default();
         let mut fynix = Fynix::new();
         let id = {
             let mut ctx = fynix.root_ctx(&mut world);
             ctx.add::<Button>()
-                .on::<Click>(|_, events| events.push(Clicked(1)))
+                .on::<Click>(|_, world| world.clicks += 1)
                 .id()
         };
 
-        assert!(fynix.interactions.remove(&id));
-        assert!(!fynix.dispatch(&id, Click));
+        // Handlers ride the element table, so removing the element
+        // drops them with it.
+        assert!(fynix.remove_element(&id));
+        assert!(!fynix.dispatch(&id, Click, &mut world));
     }
 }

--- a/crates/fynix/src/interaction.rs
+++ b/crates/fynix/src/interaction.rs
@@ -30,6 +30,23 @@ mod tests {
         }
     }
 
+    #[derive(Init, Element)]
+    struct Container {
+        #[elem(children)]
+        child: Option<ElementId>,
+    }
+
+    impl ElementBuild for Container {
+        fn build(
+            &self,
+            _id: &ElementId,
+            constraint: Constraint,
+            _nodes: &mut ElementNodes,
+        ) -> Size {
+            constraint.min
+        }
+    }
+
     struct Click;
 
     #[derive(Default)]
@@ -104,5 +121,58 @@ mod tests {
         // drops them with it.
         assert!(fynix.remove_element(&id));
         assert!(!fynix.dispatch(&id, Click, &mut world));
+    }
+
+    #[test]
+    fn bubbling_reaches_ancestor_handler() {
+        let mut world = World::default();
+        let mut fynix = Fynix::new();
+        let (parent, child) = {
+            let mut ctx = fynix.root_ctx(&mut world);
+            // The child carries no handler; adding the container sets
+            // the child's `parent_id` to the container.
+            let child = ctx.add::<Button>().id();
+            let parent = ctx
+                .add_with::<Container>(|c, _| c.child = Some(child))
+                .on::<Click>(|_, world| world.clicks += 1)
+                .id();
+            (parent, child)
+        };
+
+        // Bubbling from the child skips it and reaches the parent.
+        assert!(fynix.dispatch_bubbling(
+            &child,
+            Click,
+            &mut world,
+            |_| true,
+        ));
+        assert_eq!(world.clicks, 1);
+        // Direct dispatch to the child still finds no handler.
+        assert!(!fynix.dispatch(&child, Click, &mut world));
+        let _ = parent;
+    }
+
+    #[test]
+    fn bubbling_stops_when_gate_returns_false() {
+        let mut world = World::default();
+        let mut fynix = Fynix::new();
+        let child = {
+            let mut ctx = fynix.root_ctx(&mut world);
+            let child = ctx.add::<Button>().id();
+            ctx.add_with::<Container>(|c, _| c.child = Some(child))
+                .on::<Click>(|_, world| world.clicks += 1)
+                .id();
+            child
+        };
+
+        // The gate rejects the start element, so the walk never
+        // reaches the parent's handler.
+        assert!(!fynix.dispatch_bubbling(
+            &child,
+            Click,
+            &mut world,
+            |_| false,
+        ));
+        assert_eq!(world.clicks, 0);
     }
 }

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -88,6 +88,46 @@ impl<W> Fynix<W> {
         true
     }
 
+    /// Dispatches `interaction` to the nearest ancestor of `start`
+    /// (including `start` itself) that handles `I`, walking up the
+    /// parent chain and skipping elements with no handler.
+    ///
+    /// `should_bubble` gates each candidate: the walk stops as soon
+    /// as it returns `false`. Pass `|_| true` to always bubble to
+    /// the root, or a hit-test gate to stop at the pointer's
+    /// edge.
+    ///
+    /// Returns `true` if a handler ran.
+    pub fn dispatch_bubbling<I: 'static>(
+        &mut self,
+        start: &ElementId,
+        interaction: I,
+        world: &mut W,
+        should_bubble: impl Fn(&ElementId) -> bool,
+    ) -> bool {
+        let mut current = Some(*start);
+        while let Some(id) = current {
+            if !should_bubble(&id) {
+                break;
+            }
+            if self
+                .elements
+                .table
+                .get_component::<HandlerFn<I, W>>(&id)
+                .is_some()
+            {
+                return self.dispatch::<I>(&id, interaction, world);
+            }
+            current = self
+                .elements
+                .table
+                .node(&id)
+                .and_then(|node| node.parent_id);
+        }
+
+        false
+    }
+
     /// Lays out every dirty subtree (see [`Elements::mark_dirty`]),
     /// draining the dirty set.
     #[inline]
@@ -144,7 +184,7 @@ impl<W> Fynix<W> {
             .collect::<Vec<_>>();
 
         for (id, watcher) in watchers {
-            watcher.rebuild(id, self, world);
+            watcher.rebuild(&id, self, world);
         }
 
         let bindings = self
@@ -156,7 +196,7 @@ impl<W> Fynix<W> {
             .collect::<Vec<_>>();
 
         for (id, binding) in bindings {
-            binding.build(&id, &mut self.elements, world);
+            binding.apply(&id, &mut self.elements, world);
         }
     }
 

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -13,7 +13,7 @@ use crate::ctx::FynixCtx;
 use crate::element::{ElementId, Elements};
 use crate::interaction::HandlerFn;
 use crate::reactive::binding::Binding;
-use crate::reactive::watch::Watch;
+use crate::reactive::watcher::Watcher;
 use crate::resource::Resources;
 use crate::style::{StyleId, Styles};
 
@@ -49,14 +49,10 @@ mod id;
 ///
 /// Obtain a [`FynixCtx`] via [`Self::root_ctx`] to start building the
 /// user interface.
-pub struct Fynix<W> {
+pub struct Fynix<W: 'static> {
     pub resources: Resources,
-    elements: Elements,
+    elements: Elements<W>,
     styles: Styles,
-    /// Single backend world type. Watches, bindings, and interaction
-    /// handlers are stored as components on the element table, so
-    /// `W` only appears in the build-time and update APIs.
-    _world: core::marker::PhantomData<fn(&mut W)>,
 }
 
 impl<W> Fynix<W> {
@@ -65,7 +61,6 @@ impl<W> Fynix<W> {
             resources: Resources::new(),
             elements: Elements::new(),
             styles: Styles::new(),
-            _world: core::marker::PhantomData,
         }
     }
 
@@ -80,10 +75,7 @@ impl<W> Fynix<W> {
         id: &ElementId,
         interaction: I,
         world: &mut W,
-    ) -> bool
-    where
-        W: 'static,
-    {
+    ) -> bool {
         let Some(handler) = self
             .elements
             .table
@@ -123,7 +115,7 @@ impl<W> Fynix<W> {
         // removed element owns. The first primary style encountered
         // drops itself and all its descendants in the style tree, so
         // deeper primary styles are left for that subtree removal to
-        // handle. Watches, bindings, and interaction handlers ride
+        // handle. Watchers, bindings, and interaction handlers ride
         // the element table and are dropped with the element,
         // so only styles need explicit cleanup here.
         let mut has_removed_styles = false;
@@ -142,20 +134,17 @@ impl<W> Fynix<W> {
     /// applying every change-driven update whose source changed.
     ///
     /// Intended to be called by the backend once per frame.
-    pub fn sync(&mut self, world: &mut W)
-    where
-        W: 'static,
-    {
-        let watches = self
+    pub fn sync(&mut self, world: &mut W) {
+        let watchers = self
             .elements
             .table
-            .components::<Watch<W>>()
-            .filter(|(_, watch)| watch.is_changed(world))
-            .map(|(id, watch)| (*id, *watch))
+            .components::<Watcher<W>>()
+            .filter(|(_, watcher)| watcher.is_changed(world))
+            .map(|(id, watcher)| (*id, *watcher))
             .collect::<Vec<_>>();
 
-        for (id, watch) in watches {
-            watch.rebuild(id, self, world);
+        for (id, watcher) in watchers {
+            watcher.rebuild(id, self, world);
         }
 
         let bindings = self

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -6,13 +6,12 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 pub use field_path;
-use fynix_event::Events;
 pub use imaging;
 use imaging::PaintSink;
 
 use crate::ctx::FynixCtx;
 use crate::element::{ElementId, Elements};
-use crate::interaction::Interactions;
+use crate::interaction::HandlerFn;
 use crate::reactive::binding::Binding;
 use crate::reactive::watch::Watch;
 use crate::resource::Resources;
@@ -54,11 +53,9 @@ pub struct Fynix<W> {
     pub resources: Resources,
     elements: Elements,
     styles: Styles,
-    events: Events,
-    interactions: Interactions,
-    /// Single backend world type. Watches and bindings are stored as
-    /// components on the element table, so `W` only appears in the
-    /// build-time and update APIs.
+    /// Single backend world type. Watches, bindings, and interaction
+    /// handlers are stored as components on the element table, so
+    /// `W` only appears in the build-time and update APIs.
     _world: core::marker::PhantomData<fn(&mut W)>,
 }
 
@@ -68,28 +65,35 @@ impl<W> Fynix<W> {
             resources: Resources::new(),
             elements: Elements::new(),
             styles: Styles::new(),
-            events: Events::new(),
-            interactions: Interactions::new(),
             _world: core::marker::PhantomData,
         }
     }
 
-    /// Dispatches `interaction` to the handler registered for `id`'s
-    /// element type and the interaction type `I`, if one exists.
+    /// Dispatches `interaction` to the handler attached to `id` for
+    /// the interaction type `I`, if one exists, letting it mutate
+    /// `world`.
     ///
-    /// Returns `true` if a handler ran. Messages the handler emits
-    /// land in the event queue.
+    /// Returns `true` if a handler ran.
     #[inline]
     pub fn dispatch<I: 'static>(
         &mut self,
         id: &ElementId,
         interaction: I,
-    ) -> bool {
-        self.interactions.dispatch::<I>(
-            id,
-            interaction,
-            &mut self.events,
-        )
+        world: &mut W,
+    ) -> bool
+    where
+        W: 'static,
+    {
+        let Some(handler) = self
+            .elements
+            .table
+            .get_component::<HandlerFn<I, W>>(id)
+            .copied()
+        else {
+            return false;
+        };
+        handler(interaction, world);
+        true
     }
 
     /// Lays out every dirty subtree (see [`Elements::mark_dirty`]),
@@ -119,20 +123,18 @@ impl<W> Fynix<W> {
         // removed element owns. The first primary style encountered
         // drops itself and all its descendants in the style tree, so
         // deeper primary styles are left for that subtree removal to
-        // handle. Watches and bindings ride the element table and are
-        // dropped with the element, so only styles and interaction
-        // handlers need explicit cleanup here.
+        // handle. Watches, bindings, and interaction handlers ride
+        // the element table and are dropped with the element,
+        // so only styles need explicit cleanup here.
         let mut has_removed_styles = false;
 
-        self.elements.remove(id, |id, primary_style| {
+        self.elements.remove(id, |_id, primary_style| {
             if !has_removed_styles
                 && let Some(primary_style) = primary_style
             {
                 has_removed_styles =
                     self.styles.remove(&primary_style);
             }
-
-            self.interactions.remove(id);
         })
     }
 

--- a/crates/fynix/src/reactive.rs
+++ b/crates/fynix/src/reactive.rs
@@ -2,7 +2,7 @@
 //!
 //! Two flavors share one change-detection signal, the [`ChangedFn`]:
 //!
-//! - A [`watch`] rebuilds a whole subtree when its source changes.
+//! - A [`watcher`] rebuilds a whole subtree when its source changes.
 //! - A [`binding`] writes one field in place when its source changes.
 //!
 //! Both are stored as per-element components on the element table and
@@ -10,7 +10,7 @@
 //! [`Fynix::sync`](crate::Fynix::sync).
 
 pub mod binding;
-pub mod watch;
+pub mod watcher;
 
 /// Reports whether a reactive source changed since the last flush.
 pub type ChangedFn<W> = fn(&W) -> bool;

--- a/crates/fynix/src/reactive/binding.rs
+++ b/crates/fynix/src/reactive/binding.rs
@@ -98,9 +98,9 @@ type ApplyFn<W> = fn(
     get_mut: MutFnPtr,
 ) -> bool;
 
-/// Reads `T` from `world`, writes it into element `E`'s field, and
-/// marks the element dirty. A no-op write if the element is absent
-/// or of a different type, but it is still marked dirty.
+/// Reads `T` from `world`, writes it into element `E`'s field.
+///
+/// Returns `false` if element is absent.
 fn apply<W, E: Element, T>(
     world: &W,
     elements: &mut Elements<W>,

--- a/crates/fynix/src/reactive/binding.rs
+++ b/crates/fynix/src/reactive/binding.rs
@@ -59,13 +59,23 @@ impl<W> Binding<W> {
 
     /// Reads the new value from `world` and writes it into `id`,
     /// marking it dirty.
-    pub fn build(
+    pub fn apply(
         &self,
         id: &ElementId,
         elements: &mut Elements<W>,
         world: &W,
     ) {
-        (self.apply_fn)(world, elements, id, self.get_fn, self.mut_fn)
+        let success = (self.apply_fn)(
+            world,
+            elements,
+            id,
+            self.get_fn,
+            self.mut_fn,
+        );
+
+        if success {
+            elements.mark_dirty(*id);
+        }
     }
 }
 
@@ -86,7 +96,7 @@ type ApplyFn<W> = fn(
     id: &ElementId,
     get_fn: GetFnPtr,
     get_mut: MutFnPtr,
-);
+) -> bool;
 
 /// Reads `T` from `world`, writes it into element `E`'s field, and
 /// marks the element dirty. A no-op write if the element is absent
@@ -97,15 +107,17 @@ fn apply<W, E: Element, T>(
     id: &ElementId,
     get_fn: GetFnPtr,
     get_mut: MutFnPtr,
-) {
+) -> bool {
     if let Some(element) = elements.get_typed_mut::<E>(id) {
         let get_fn = unsafe { get_fn.typed_unchecked::<W, T>() };
         let get_mut = unsafe { get_mut.typed_unchecked::<E, T>() };
 
         let v = get_fn(world);
         *get_mut(element) = v;
+
+        return true;
     }
-    elements.mark_dirty(*id);
+    false
 }
 
 /// A type-erased [`GetFn`] (the world value reader) stored on a

--- a/crates/fynix/src/reactive/binding.rs
+++ b/crates/fynix/src/reactive/binding.rs
@@ -138,3 +138,129 @@ impl GetFnPtr {
 
 /// Reads a value of type `T` from the world.
 pub type GetFn<W, T> = fn(&W) -> T;
+
+#[cfg(test)]
+mod tests {
+    use rectree::{Constraint, Size};
+
+    use crate::Fynix;
+    use crate::element::layout::ElementNodes;
+    use crate::element::{Element, ElementBuild, ElementId};
+    use crate::init::Init;
+
+    #[derive(Init, Element)]
+    struct Counter {
+        n: u32,
+    }
+
+    impl ElementBuild for Counter {
+        fn build(
+            &self,
+            _id: &ElementId,
+            constraint: Constraint,
+            _nodes: &mut ElementNodes,
+        ) -> Size {
+            constraint.min
+        }
+    }
+
+    #[derive(Default)]
+    struct World {
+        changed: bool,
+        value: u32,
+    }
+
+    /// A binding writes the world value into the field only on a
+    /// flush where `changed` reports true, leaving it untouched
+    /// otherwise.
+    #[test]
+    fn writes_field_only_when_changed() {
+        let mut world = World {
+            changed: false,
+            value: 1,
+        };
+        let mut fynix = Fynix::<World>::new();
+
+        let id = {
+            let mut ctx = fynix.root_ctx(&mut world);
+            ctx.add::<Counter>()
+                .bind(|w| w.changed, |w| w.value, |c| &mut c.n)
+                .id()
+        };
+
+        let n = |fynix: &Fynix<World>| {
+            fynix.elements.get_typed::<Counter>(&id).unwrap().n
+        };
+
+        // Binding does not apply on attach; the field keeps its
+        // initial value.
+        assert_eq!(n(&fynix), 0);
+
+        // Value changes but `changed` is false: no write.
+        world.value = 2;
+        fynix.sync(&mut world);
+        assert_eq!(n(&fynix), 0);
+
+        // Flip `changed`: the field picks up the current value.
+        world.changed = true;
+        fynix.sync(&mut world);
+        assert_eq!(n(&fynix), 2);
+    }
+
+    /// A binding writes only into the element it was attached to,
+    /// leaving sibling instances of the same type alone.
+    #[test]
+    fn applies_only_to_bound_instance() {
+        let mut world = World {
+            changed: true,
+            value: 7,
+        };
+        let mut fynix = Fynix::<World>::new();
+
+        let (bound, plain) = {
+            let mut ctx = fynix.root_ctx(&mut world);
+            let bound = ctx
+                .add::<Counter>()
+                .bind(|w| w.changed, |w| w.value, |c| &mut c.n)
+                .id();
+            let plain = ctx.add::<Counter>().id();
+            (bound, plain)
+        };
+
+        fynix.sync(&mut world);
+
+        assert_eq!(
+            fynix.elements.get_typed::<Counter>(&bound).unwrap().n,
+            7
+        );
+        assert_eq!(
+            fynix.elements.get_typed::<Counter>(&plain).unwrap().n,
+            0
+        );
+    }
+
+    /// Removing the element drops its binding with it, so a later
+    /// flush is a no-op for that id rather than a stale write.
+    #[test]
+    fn removing_element_drops_binding() {
+        let mut world = World {
+            changed: true,
+            value: 5,
+        };
+        let mut fynix = Fynix::<World>::new();
+
+        let id = {
+            let mut ctx = fynix.root_ctx(&mut world);
+            ctx.add::<Counter>()
+                .bind(|w| w.changed, |w| w.value, |c| &mut c.n)
+                .id()
+        };
+
+        assert!(fynix.remove_element(&id));
+
+        // The binding rode the element table and is gone, so this
+        // flush finds nothing to apply and does not panic.
+        fynix.sync(&mut world);
+        assert!(fynix.elements.get_typed::<Counter>(&id).is_none());
+    }
+}

--- a/crates/fynix/src/reactive/binding.rs
+++ b/crates/fynix/src/reactive/binding.rs
@@ -2,10 +2,10 @@
 //! driven by world change detection.
 //!
 //! A binding is the lightweight counterpart to a
-//! [`Watch`](crate::reactive::watch::Watch). Where a watch rebuilds a
-//! whole subtree, a binding reads one value from the world and writes
-//! it into one element field, then marks that element dirty. Bindings
-//! are attached per instance via
+//! [`Watcher`](crate::reactive::watcher::Watcher). Where a watcher
+//! rebuilds a whole subtree, a binding reads one value from the world
+//! and writes it into one element field, then marks it dirty.
+//! Bindings are attached per instance via
 //! [`ElementCtx::bind`](crate::ctx::ElementCtx::bind) and flushed
 //! each frame by [`Fynix::sync`](crate::Fynix::sync).
 
@@ -26,7 +26,7 @@ use crate::reactive::ChangedFn;
 ///
 /// [`ElementTable::insert_component`]: crate::element::table::ElementTable::insert_component
 #[derive(Debug)]
-pub struct Binding<W> {
+pub struct Binding<W: 'static> {
     /// Reports whether the bound source changed since the last
     /// apply.
     changed_fn: ChangedFn<W>,
@@ -62,7 +62,7 @@ impl<W> Binding<W> {
     pub fn build(
         &self,
         id: &ElementId,
-        elements: &mut Elements,
+        elements: &mut Elements<W>,
         world: &W,
     ) {
         (self.apply_fn)(world, elements, id, self.get_fn, self.mut_fn)
@@ -82,7 +82,7 @@ impl<W> Clone for Binding<W> {
 /// field write.
 type ApplyFn<W> = fn(
     world: &W,
-    elements: &mut Elements,
+    elements: &mut Elements<W>,
     id: &ElementId,
     get_fn: GetFnPtr,
     get_mut: MutFnPtr,
@@ -93,7 +93,7 @@ type ApplyFn<W> = fn(
 /// or of a different type, but it is still marked dirty.
 fn apply<W, E: Element, T>(
     world: &W,
-    elements: &mut Elements,
+    elements: &mut Elements<W>,
     id: &ElementId,
     get_fn: GetFnPtr,
     get_mut: MutFnPtr,

--- a/crates/fynix/src/reactive/watcher.rs
+++ b/crates/fynix/src/reactive/watcher.rs
@@ -89,13 +89,13 @@ impl<W> Watcher<W> {
     /// was dropped with it).
     pub fn rebuild(
         &self,
-        id: ElementId,
+        id: &ElementId,
         fynix: &mut Fynix<W>,
         world: &mut W,
     ) {
         let Some(old_child) = fynix
             .elements
-            .get_typed_mut::<WatcherElement>(&id)
+            .get_typed_mut::<WatcherElement>(id)
             .map(|elem| elem.child.take())
         else {
             return;
@@ -117,17 +117,17 @@ impl<W> Watcher<W> {
             && let Some(node) =
                 fynix.elements.table.node_mut(&child_id)
         {
-            node.parent_id = Some(id);
+            node.parent_id = Some(*id);
         }
         if let Some(elem) =
-            fynix.elements.get_typed_mut::<WatcherElement>(&id)
+            fynix.elements.get_typed_mut::<WatcherElement>(id)
         {
             elem.child = child;
         }
 
         // Mark the rebuilt subtree dirty so it is re-laid-out and
         // re-rendered.
-        fynix.elements.mark_dirty(id);
+        fynix.elements.mark_dirty(*id);
     }
 }
 

--- a/crates/fynix/src/reactive/watcher.rs
+++ b/crates/fynix/src/reactive/watcher.rs
@@ -1,9 +1,9 @@
-//! Watches: subtree rebuilds driven by world change detection.
+//! Watchers: subtree rebuilds driven by world change detection.
 //!
-//! A watch is the heavyweight counterpart to a
+//! A watcher is the heavyweight counterpart to a
 //! [`Binding`](crate::reactive::binding::Binding). Where a binding
-//! writes one field in place, a watch rebuilds a whole subtree when
-//! the world state it reads changes. Watches are attached via
+//! writes one field in place, a watcher rebuilds a whole subtree when
+//! the world state it reads changes. Watchers are attached via
 //! [`FynixCtx::watch`](crate::ctx::FynixCtx::watch) and flushed each
 //! frame by [`Fynix::sync`](crate::Fynix::sync).
 
@@ -18,12 +18,12 @@ use crate::reactive::ChangedFn;
 use crate::style::StyleId;
 
 #[derive(Init, Element)]
-pub struct WatchElement {
+pub struct WatcherElement {
     #[elem(children)]
     pub(crate) child: Option<ElementId>,
 }
 
-impl ElementBuild for WatchElement {
+impl ElementBuild for WatcherElement {
     fn build(
         &self,
         _id: &ElementId,
@@ -44,24 +44,25 @@ impl ElementBuild for WatchElement {
 
 pub type BuildFn<W> = fn(&mut FynixCtx<W>) -> Option<ElementId>;
 
-/// A watch, stored as a component on its [`WatchElement`] holder (see
-/// [`ElementTable::insert_component`]). The holder's [`ElementId`] is
-/// the component key, so the watch carries no id of its own.
+/// A watcher, stored as a component on its [`WatcherElement`] holder
+/// (see [`ElementTable::insert_component`]). The holder's
+/// [`ElementId`] is the component key, so the watcher carries no id
+/// of its own.
 ///
 /// [`ElementTable::insert_component`]: crate::element::table::ElementTable::insert_component
 #[derive(Debug)]
-pub struct Watch<W> {
+pub struct Watcher<W: 'static> {
     /// Reports whether the watched source changed since the last
-    /// flush, requiring a rebuild of [`WatchElement::child`].
+    /// flush, requiring a rebuild of [`WatcherElement::child`].
     changed_fn: ChangedFn<W>,
-    /// Builds the replacement for [`WatchElement::child`].
+    /// Builds the replacement for [`WatcherElement::child`].
     build_fn: BuildFn<W>,
-    /// Style scope active when the watch was created. Restored on
+    /// Style scope active when the watcher was created. Restored on
     /// each rebuild so the subtree is styled like its first build.
     style_id: Option<StyleId>,
 }
 
-impl<W> Watch<W> {
+impl<W> Watcher<W> {
     pub(crate) fn new(
         changed_fn: ChangedFn<W>,
         build_fn: BuildFn<W>,
@@ -79,13 +80,13 @@ impl<W> Watch<W> {
         (self.changed_fn)(world)
     }
 
-    /// Rebuilds the subtree under the [`WatchElement`] at `id`: drops
-    /// the old child, builds a fresh one under the captured style
-    /// scope, re-parents it, and marks the holder dirty.
+    /// Rebuilds the subtree under the [`WatcherElement`] at `id`:
+    /// drops the old child, builds a fresh one under the captured
+    /// style scope, re-parents it, and marks the holder dirty.
     ///
     /// A no-op if the holder is gone, e.g. when an ancestor's rebuild
-    /// already discarded it earlier in the same flush (the watch was
-    /// dropped with it).
+    /// already discarded it earlier in the same flush (the watcher
+    /// was dropped with it).
     pub fn rebuild(
         &self,
         id: ElementId,
@@ -94,7 +95,7 @@ impl<W> Watch<W> {
     ) {
         let Some(old_child) = fynix
             .elements
-            .get_typed_mut::<WatchElement>(&id)
+            .get_typed_mut::<WatcherElement>(&id)
             .map(|elem| elem.child.take())
         else {
             return;
@@ -104,7 +105,7 @@ impl<W> Watch<W> {
             fynix.remove_element(&old_child);
         }
 
-        // Rebuild under the watch's captured style scope, then drop
+        // Rebuild under the watcher's captured style scope, then drop
         // any uncommitted style changes so they do not leak.
         let child = {
             let mut ctx = fynix.create_ctx(world, self.style_id);
@@ -119,7 +120,7 @@ impl<W> Watch<W> {
             node.parent_id = Some(id);
         }
         if let Some(elem) =
-            fynix.elements.get_typed_mut::<WatchElement>(&id)
+            fynix.elements.get_typed_mut::<WatcherElement>(&id)
         {
             elem.child = child;
         }
@@ -130,9 +131,9 @@ impl<W> Watch<W> {
     }
 }
 
-impl<W> Copy for Watch<W> {}
+impl<W> Copy for Watcher<W> {}
 
-impl<W> Clone for Watch<W> {
+impl<W> Clone for Watcher<W> {
     fn clone(&self) -> Self {
         *self
     }
@@ -167,7 +168,7 @@ mod tests {
         value: u32,
     }
 
-    /// The watch captures `value` at build time and only rebuilds
+    /// The watcher captures `value` at build time and only rebuilds
     /// when `changed` reports true, picking up the new value then.
     #[test]
     fn rebuilds_only_when_changed() {
@@ -195,7 +196,7 @@ mod tests {
         let child_n = |fynix: &Fynix<World>| {
             let child = fynix
                 .elements
-                .get_typed::<WatchElement>(&holder)
+                .get_typed::<WatcherElement>(&holder)
                 .unwrap()
                 .child
                 .unwrap();

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -6,7 +6,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use fynix::element::layout::ElementNodes;
-use fynix::element::table::ElementTable;
+use fynix::element::table::RenderElementTable;
 use fynix::imaging::kurbo::{Affine, Stroke};
 use fynix::imaging::peniko::{Brush, BrushRef, Color, Fill, Style};
 use fynix::imaging::record::{Glyph, Scene, replay_transformed};
@@ -239,7 +239,7 @@ impl ElementBuild for Button {
         &self,
         id: &ElementId,
         painter: &mut dyn PaintSink,
-        table: &ElementTable,
+        table: RenderElementTable,
     ) {
         let Some(node) = table.node(id) else { return };
         let pos = node.world_translation;
@@ -359,7 +359,7 @@ impl ElementBuild for Label {
         &self,
         id: &ElementId,
         painter: &mut dyn PaintSink,
-        table: &ElementTable,
+        table: RenderElementTable,
     ) {
         let Some(node) = table.node(id) else { return };
         let Some(scene) = table.scene(id) else {

--- a/crates/fynix_hit_test/src/lib.rs
+++ b/crates/fynix_hit_test/src/lib.rs
@@ -57,8 +57,8 @@ impl HitTest {
     ///
     /// Layout must be complete so each element's `world_translation`
     /// and `size` are current.
-    pub fn build(
-        elements: &Elements,
+    pub fn build<W: 'static>(
+        elements: &Elements<W>,
         root: &ElementId,
         include: impl Fn(&ElementId) -> bool,
     ) -> Self {


### PR DESCRIPTION
Interaction handlers now take in `&mut W` world as opposed to `&mut Events`.
`Events` are meant to be opt-in, and can be used when the backend world does not have any event system at all.