### PR TITLE
Add Frame and Overlay elements + CAD toolbar example

### DIFF
--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -1,5 +1,3 @@
-use alloc::boxed::Box;
-
 use field_path::accessor::func_pointers::MutFn;
 use field_path::field_accessor::FieldAccessor;
 
@@ -8,7 +6,7 @@ use crate::composer::Composer;
 use crate::element::storage::ElementHandle;
 use crate::element::{Element, ElementId};
 use crate::init::Init;
-use crate::interaction::{Handler, Response};
+use crate::interaction::{Handler, HandlerFn};
 use crate::reactive::ChangedFn;
 use crate::reactive::binding::{Binding, GetFn};
 use crate::reactive::watcher::{BuildFn, Watcher, WatcherElement};
@@ -259,8 +257,7 @@ impl<'f, W, E: Element> ElementCtx<'f, W, E> {
     /// this element, which is then marked dirty. Unlike a watcher,
     /// nothing is rebuilt: only the field is updated in place.
     ///
-    /// Chainable, and applied each frame by
-    /// [`Fynix::sync`](crate::Fynix::sync).
+    /// Chainable, and applied each frame by [`Fynix::sync`].
     #[must_use]
     pub fn bind<T>(
         self,
@@ -279,10 +276,9 @@ impl<'f, W, E: Element> ElementCtx<'f, W, E> {
     /// Attaches an already-built [`Handler`] for interaction type `I`
     /// to this element.
     ///
-    /// The lower-level entry point behind [`Self::interact`] and
-    /// [`Self::interact_with`]; useful for forwarding a stored
-    /// handler. A later call for the same `I` replaces the earlier
-    /// one.
+    /// The lower-level entry point behind [`Self::interact`]; useful
+    /// for forwarding a stored handler. A later call for the same `I`
+    /// replaces the earlier one.
     #[must_use]
     pub fn interact_raw<I: 'static>(
         self,
@@ -295,29 +291,17 @@ impl<'f, W, E: Element> ElementCtx<'f, W, E> {
         self
     }
 
-    /// Attaches a non-capturing handler (without heap allocation) for
-    /// interaction type `I` to this element.
+    /// Attaches a handler for interaction type `I` to this element.
     ///
-    /// For a capturing closure, use [`Self::interact_with`].
+    /// `I` is inferred from the handler's parameter. The closure may
+    /// capture its environment. A later call for the same `I`
+    /// replaces the earlier one.
     #[must_use]
     pub fn interact<I: 'static>(
         self,
-        handler: fn(I, &mut Response<'_, W>),
+        handler: impl HandlerFn<I, W>,
     ) -> Self {
-        self.interact_raw(Handler::Ptr(handler))
-    }
-
-    /// Attaches a capturing handler for interaction type `I` to this
-    /// element, stored boxed.
-    ///
-    /// Like [`Self::interact`], but accepts any closure that captures
-    /// its environment, at the cost of a heap allocation.
-    #[must_use]
-    pub fn interact_with<I: 'static>(
-        self,
-        handler: impl Fn(I, &mut Response<'_, W>) + 'static,
-    ) -> Self {
-        self.interact_raw(Handler::Boxed(Box::new(handler)))
+        self.interact_raw(Handler::new(handler))
     }
 
     /// Returns the element's handle.

--- a/crates/fynix/src/ctx.rs
+++ b/crates/fynix/src/ctx.rs
@@ -1,4 +1,3 @@
-use field_path::accessor::func_pointers::MutFn;
 use field_path::field_accessor::FieldAccessor;
 
 use crate::Fynix;
@@ -8,7 +7,7 @@ use crate::element::{Element, ElementId};
 use crate::init::Init;
 use crate::interaction::{Handler, HandlerFn};
 use crate::reactive::ChangedFn;
-use crate::reactive::binding::{Binding, GetFn};
+use crate::reactive::binding::{Binding, GetFn, SetFn};
 use crate::reactive::watcher::{BuildFn, Watcher, WatcherElement};
 use crate::style::{Stylable, StyleId, StyleValue};
 
@@ -134,8 +133,8 @@ impl<W> FynixCtx<'_, '_, W> {
     #[must_use]
     pub fn watch(
         &mut self,
-        changed: ChangedFn<W>,
-        build: BuildFn<W>,
+        changed: impl ChangedFn<W>,
+        build: impl BuildFn<W>,
     ) -> ElementCtx<'_, W, WatcherElement> {
         self.commit_pending_styles();
 
@@ -145,15 +144,17 @@ impl<W> FynixCtx<'_, '_, W> {
         let element_handle =
             self.fynix.elements.add(WatcherElement::init(), None);
         let element_id = element_handle.as_id();
+
+        // Build the initial subtree under the current style scope,
+        // before `build` is moved into the watcher.
+        let child = build(self);
+        // Clear any uncommitted style changes to prevent leaking.
+        self.fynix.styles.clear_builder();
+
         self.fynix.elements.table.insert_watcher(
             element_id,
             Watcher::new(changed, build, style_id),
         );
-
-        // Build the initial subtree under the current style scope.
-        let child = build(self);
-        // Clear any uncommitted style changes to prevent leaking.
-        self.fynix.styles.clear_builder();
 
         if let Some(child_id) = child
             && let Some(node) =
@@ -252,24 +253,24 @@ impl<'f, W, E: Element> ElementCtx<'f, W, E> {
 
     /// Binds one of this element's fields to the world.
     ///
-    /// When `changed_fn` reports a change, `get_fn` reads the new
-    /// value from the world and it is written through `mut_fn` into
-    /// this element, which is then marked dirty. Unlike a watcher,
-    /// nothing is rebuilt: only the field is updated in place.
+    /// When `changed` reports a change, `get` reads the new value
+    /// from the world and it is written through `set` into this
+    /// element, which is then marked dirty. Unlike a watcher, nothing
+    /// is rebuilt: only the field is updated in place.
     ///
     /// Chainable, and applied each frame by [`Fynix::sync`].
     #[must_use]
-    pub fn bind<T>(
+    pub fn bind<T: 'static>(
         self,
-        changed_fn: ChangedFn<W>,
-        get_fn: GetFn<W, T>,
-        mut_fn: MutFn<E, T>,
+        changed: impl ChangedFn<W>,
+        get: impl GetFn<W, T>,
+        set: impl SetFn<E, T>,
     ) -> Self {
         let id = self.id();
-        self.fynix.elements.table.insert_binding(
-            id,
-            Binding::new(changed_fn, get_fn, mut_fn),
-        );
+        self.fynix
+            .elements
+            .table
+            .insert_binding(id, Binding::new(changed, get, set));
         self
     }
 

--- a/crates/fynix/src/interaction.rs
+++ b/crates/fynix/src/interaction.rs
@@ -69,49 +69,44 @@ impl<W> DerefMut for Response<'_, W> {
 /// A user-written interaction handler reacting to interaction `I` by
 /// mutating the world through the [`Response`].
 ///
-/// Stored per instance as an element-table component, one per
-/// `(element, I)`. A non-capturing handler stays a bare function
-/// pointer ([`Self::Ptr`], no allocation, attached via
-/// [`interact`](crate::ctx::ElementCtx::interact)); a capturing one
-/// is boxed ([`Self::Boxed`], attached via
-/// [`interact_with`](crate::ctx::ElementCtx::interact_with)). The
-/// handler consumes the interaction by default; call
+/// A boxed closure, so it may capture its environment. Stored per
+/// instance as an element-table component, one per `(element, I)`,
+/// and attached via [`interact`](crate::ctx::ElementCtx::interact).
+/// The handler consumes the interaction by default; call
 /// [`Response::propagate`] to let it bubble instead.
-pub enum Handler<I, W> {
-    /// A non-capturing handler, stored as a plain function pointer.
-    Ptr(fn(I, &mut Response<'_, W>)),
-    /// A capturing handler, stored boxed.
-    #[expect(clippy::type_complexity)]
-    Boxed(Box<dyn Fn(I, &mut Response<'_, W>)>),
-}
+pub struct Handler<I, W>(Box<dyn HandlerFn<I, W>>);
 
 impl<I, W> Handler<I, W> {
-    /// Runs the handler, passing `interaction` and the `response`.
+    /// Boxes `handler` for storage.
+    pub fn new(handler: impl HandlerFn<I, W>) -> Self {
+        Self(Box::new(handler))
+    }
+
+    /// Runs the handler with `interaction` and the `response`.
     #[inline]
     pub fn call(
         &self,
         interaction: I,
         response: &mut Response<'_, W>,
     ) {
-        match self {
-            Self::Ptr(f) => f(interaction, response),
-            Self::Boxed(f) => f(interaction, response),
-        }
+        (self.0)(interaction, response)
     }
 }
 
-impl<I, W> From<fn(I, &mut Response<'_, W>)> for Handler<I, W> {
-    fn from(handler: fn(I, &mut Response<'_, W>)) -> Self {
-        Self::Ptr(handler)
+impl<I, W, F: HandlerFn<I, W>> From<F> for Handler<I, W> {
+    fn from(handler: F) -> Self {
+        Self::new(handler)
     }
 }
 
-impl<I, W> From<Box<dyn Fn(I, &mut Response<'_, W>)>>
-    for Handler<I, W>
+pub trait HandlerFn<I, W>:
+    Fn(I, &mut Response<'_, W>) + 'static
 {
-    fn from(handler: Box<dyn Fn(I, &mut Response<'_, W>)>) -> Self {
-        Self::Boxed(handler)
-    }
+}
+
+impl<I, W, F> HandlerFn<I, W> for F where
+    F: Fn(I, &mut Response<'_, W>) + 'static
+{
 }
 
 #[cfg(test)]

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -8,6 +8,7 @@ use alloc::vec::Vec;
 pub use field_path;
 pub use imaging;
 use imaging::PaintSink;
+pub use rectree::RectNodes;
 
 use crate::ctx::FynixCtx;
 use crate::element::observer::ObserverFn;

--- a/crates/fynix/src/lib.rs
+++ b/crates/fynix/src/lib.rs
@@ -14,7 +14,7 @@ use crate::element::observer::ObserverFn;
 use crate::element::{ElementId, Elements};
 use crate::interaction::{Handler, Response};
 use crate::reactive::binding::Binding;
-use crate::reactive::watcher::Watcher;
+use crate::reactive::watcher::{Watcher, WatcherElement};
 use crate::resource::Resources;
 use crate::style::{StyleId, Styles};
 
@@ -207,28 +207,55 @@ impl<W> Fynix<W> {
     ///
     /// Intended to be called by the backend once per frame.
     pub fn sync(&mut self, world: &mut W) {
-        let watchers = self
+        // Watchers and bindings are not `Copy`, so take each changed
+        // one out of the table, run it (which is then free to mutate
+        // the table), then re-attach it.
+        let watcher_ids = self
             .elements
             .table
             .components::<Watcher<W>>()
             .filter(|(_, watcher)| watcher.is_changed(world))
-            .map(|(id, watcher)| (*id, *watcher))
+            .map(|(id, _)| *id)
             .collect::<Vec<_>>();
 
-        for (id, watcher) in watchers {
+        for id in watcher_ids {
+            let Some(watcher) = self
+                .elements
+                .table
+                .remove_component::<Watcher<W>>(&id)
+            else {
+                continue;
+            };
             watcher.rebuild(&id, self, world);
+            // An ancestor rebuild may have discarded the holder; only
+            // re-attach if it survived.
+            if self
+                .elements
+                .get_typed::<WatcherElement>(&id)
+                .is_some()
+            {
+                self.elements.table.insert_watcher(id, watcher);
+            }
         }
 
-        let bindings = self
+        let binding_ids = self
             .elements
             .table
             .components::<Binding<W>>()
             .filter(|(_, binding)| binding.is_changed(world))
-            .map(|(id, binding)| (*id, *binding))
+            .map(|(id, _)| *id)
             .collect::<Vec<_>>();
 
-        for (id, binding) in bindings {
+        for id in binding_ids {
+            let Some(binding) = self
+                .elements
+                .table
+                .remove_component::<Binding<W>>(&id)
+            else {
+                continue;
+            };
             binding.apply(&id, &mut self.elements, world);
+            self.elements.table.insert_binding(id, binding);
         }
     }
 

--- a/crates/fynix/src/reactive.rs
+++ b/crates/fynix/src/reactive.rs
@@ -9,8 +9,34 @@
 //! flushed together each frame by
 //! [`Fynix::sync`](crate::Fynix::sync).
 
+use alloc::boxed::Box;
+
 pub mod binding;
 pub mod watcher;
 
-/// Reports whether a reactive source changed since the last flush.
-pub type ChangedFn<W> = fn(&W) -> bool;
+/// A boxed change-detection predicate: the shared signal both
+/// bindings and watchers flush on. May capture the state it compares
+/// against.
+pub struct Changed<W>(Box<dyn ChangedFn<W>>);
+
+impl<W> Changed<W> {
+    /// Boxes `changed` for storage.
+    pub fn new(changed: impl ChangedFn<W>) -> Self {
+        Self(Box::new(changed))
+    }
+
+    /// Returns `true` if the source changed since the last flush.
+    pub fn is_changed(&self, world: &W) -> bool {
+        (self.0)(world)
+    }
+}
+
+/// Shorthand for the closure a [`Changed`] accepts: any
+/// `Fn(&W) -> bool + 'static`.
+///
+/// A blanket impl covers every matching closure, so this reads as a
+/// trait alias at `impl` sites (e.g.
+/// [`bind`](crate::ctx::ElementCtx::bind)).
+pub trait ChangedFn<W>: Fn(&W) -> bool + 'static {}
+
+impl<W, F> ChangedFn<W> for F where F: Fn(&W) -> bool + 'static {}

--- a/crates/fynix/src/reactive/binding.rs
+++ b/crates/fynix/src/reactive/binding.rs
@@ -44,7 +44,8 @@ type ApplyFn<W> =
 ///
 /// [`ElementTable::insert_component`]: crate::element::table::ElementTable::insert_component
 pub struct Binding<W: 'static> {
-    /// Reports whether the bound source changed since the last apply.
+    /// Reports whether the bound source changed since the last
+    /// apply.
     changed: Changed<W>,
     /// Reads the world and writes the captured field.
     apply: ApplyFn<W>,

--- a/crates/fynix/src/reactive/binding.rs
+++ b/crates/fynix/src/reactive/binding.rs
@@ -9,52 +9,69 @@
 //! [`ElementCtx::bind`](crate::ctx::ElementCtx::bind) and flushed
 //! each frame by [`Fynix::sync`](crate::Fynix::sync).
 
-use field_path::accessor::func_pointers::{MutFn, MutFnPtr};
+use alloc::boxed::Box;
 
 use crate::element::{Element, ElementId, Elements};
-use crate::reactive::ChangedFn;
+use crate::reactive::{Changed, ChangedFn};
+
+/// Shorthand for the world reader a binding accepts: any
+/// `Fn(&W) -> T + 'static`.
+pub trait GetFn<W, T>: Fn(&W) -> T + 'static {}
+
+impl<W, T, F> GetFn<W, T> for F where F: Fn(&W) -> T + 'static {}
+
+/// Shorthand for the field accessor a binding accepts: any
+/// `Fn(&mut E) -> &mut T + 'static`.
+pub trait SetFn<E, T>: Fn(&mut E) -> &mut T + 'static {}
+
+impl<E, T, F> SetFn<E, T> for F where F: Fn(&mut E) -> &mut T + 'static
+{}
+
+/// Reads the new value from the world and writes it into the target
+/// element's field, returning `false` if the element is absent.
+type ApplyFn<W> =
+    Box<dyn Fn(&ElementId, &mut Elements<W>, &W) -> bool>;
 
 /// A single field binding, stored as a component on the element it
 /// writes into (see [`ElementTable::insert_component`]). The target
 /// element's [`ElementId`] is the component key, so the binding
 /// carries no id of its own.
 ///
-/// It reads `T` from the world and writes it into element `E`'s field
-/// when the source changes. `get_fn` and `mut_fn` are type-erased to
-/// keep `Binding` free of the `E`/`T` parameters; `apply_fn` is the
-/// monomorphized writer that restores them and performs the write.
+/// It reads a value from the world and writes it into the bound
+/// element's field when the source changes. The reader and field
+/// accessor are captured in a boxed `apply` closure, so `Binding`
+/// stays free of the `E`/`T` parameters without any type erasure.
 ///
 /// [`ElementTable::insert_component`]: crate::element::table::ElementTable::insert_component
-#[derive(Debug)]
 pub struct Binding<W: 'static> {
-    /// Reports whether the bound source changed since the last
-    /// apply.
-    changed_fn: ChangedFn<W>,
-    /// Type-erased `fn(&W) -> T` reading the new value.
-    get_fn: GetFnPtr,
-    /// Type-erased `fn(&mut E) -> &mut T` to the target field.
-    mut_fn: MutFnPtr,
-    /// Monomorphized writer that re-types and applies the value.
-    apply_fn: ApplyFn<W>,
+    /// Reports whether the bound source changed since the last apply.
+    changed: Changed<W>,
+    /// Reads the world and writes the captured field.
+    apply: ApplyFn<W>,
 }
 
 impl<W> Binding<W> {
-    pub(crate) fn new<E: Element, T>(
-        changed_fn: ChangedFn<W>,
-        get_fn: GetFn<W, T>,
-        mut_fn: MutFn<E, T>,
+    pub(crate) fn new<E: Element, T: 'static>(
+        changed: impl ChangedFn<W>,
+        get: impl GetFn<W, T>,
+        set: impl SetFn<E, T>,
     ) -> Self {
         Self {
-            changed_fn,
-            get_fn: GetFnPtr::new(get_fn),
-            mut_fn: MutFnPtr::new(mut_fn),
-            apply_fn: apply::<W, E, T>,
+            changed: Changed::new(changed),
+            apply: Box::new(move |id, elements, world| {
+                let Some(element) = elements.get_typed_mut::<E>(id)
+                else {
+                    return false;
+                };
+                *set(element) = get(world);
+                true
+            }),
         }
     }
 
     /// Returns `true` if the bound source changed.
     pub fn is_changed(&self, world: &W) -> bool {
-        (self.changed_fn)(world)
+        self.changed.is_changed(world)
     }
 
     /// Reads the new value from `world` and writes it into `id`,
@@ -65,91 +82,11 @@ impl<W> Binding<W> {
         elements: &mut Elements<W>,
         world: &W,
     ) {
-        let success = (self.apply_fn)(
-            world,
-            elements,
-            id,
-            self.get_fn,
-            self.mut_fn,
-        );
-
-        if success {
+        if (self.apply)(id, elements, world) {
             elements.mark_dirty(*id);
         }
     }
 }
-
-impl<W> Copy for Binding<W> {}
-
-impl<W> Clone for Binding<W> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-/// Type-erased writer stored on a [`Binding`]. Monomorphized per
-/// `(W, E, T)`, it restores the erased accessors and performs the
-/// field write.
-type ApplyFn<W> = fn(
-    world: &W,
-    elements: &mut Elements<W>,
-    id: &ElementId,
-    get_fn: GetFnPtr,
-    get_mut: MutFnPtr,
-) -> bool;
-
-/// Reads `T` from `world`, writes it into element `E`'s field.
-///
-/// Returns `false` if element is absent.
-fn apply<W, E: Element, T>(
-    world: &W,
-    elements: &mut Elements<W>,
-    id: &ElementId,
-    get_fn: GetFnPtr,
-    get_mut: MutFnPtr,
-) -> bool {
-    if let Some(element) = elements.get_typed_mut::<E>(id) {
-        let get_fn = unsafe { get_fn.typed_unchecked::<W, T>() };
-        let get_mut = unsafe { get_mut.typed_unchecked::<E, T>() };
-
-        let v = get_fn(world);
-        *get_mut(element) = v;
-
-        return true;
-    }
-    false
-}
-
-/// A type-erased [`GetFn`] (the world value reader) stored on a
-/// [`Binding`] so it carries no `T` parameter.
-#[derive(Debug, Clone, Copy)]
-struct GetFnPtr(*const ());
-
-unsafe impl Send for GetFnPtr {}
-unsafe impl Sync for GetFnPtr {}
-
-impl GetFnPtr {
-    /// Erases a [`GetFn<W, T>`].
-    const fn new<W, T>(f: GetFn<W, T>) -> Self {
-        Self(f as *const ())
-    }
-
-    /// Re-interprets this pointer as a typed [`GetFn`] without
-    /// checking type correctness.
-    ///
-    /// # Safety
-    ///
-    /// Undefined behavior if `S` and `T` do not match the types used
-    /// when constructing this pointer.
-    const unsafe fn typed_unchecked<S, T>(&self) -> GetFn<S, T> {
-        unsafe {
-            core::mem::transmute::<*const (), GetFn<S, T>>(self.0)
-        }
-    }
-}
-
-/// Reads a value of type `T` from the world.
-pub type GetFn<W, T> = fn(&W) -> T;
 
 #[cfg(test)]
 mod tests {

--- a/crates/fynix/src/reactive/watcher.rs
+++ b/crates/fynix/src/reactive/watcher.rs
@@ -7,6 +7,8 @@
 //! [`FynixCtx::watch`](crate::ctx::FynixCtx::watch) and flushed each
 //! frame by [`Fynix::sync`](crate::Fynix::sync).
 
+use alloc::boxed::Box;
+
 use rectree::{Constraint, NodeContext, Size, Vec2};
 
 use crate::Fynix;
@@ -14,7 +16,7 @@ use crate::ctx::FynixCtx;
 use crate::element::layout::ElementNodes;
 use crate::element::{Element, ElementBuild, ElementId};
 use crate::init::Init;
-use crate::reactive::ChangedFn;
+use crate::reactive::{Changed, ChangedFn};
 use crate::style::StyleId;
 
 #[derive(Init, Element)]
@@ -42,7 +44,17 @@ impl ElementBuild for WatcherElement {
     }
 }
 
-pub type BuildFn<W> = fn(&mut FynixCtx<W>) -> Option<ElementId>;
+/// Shorthand for the subtree builder a watcher accepts: any
+/// `Fn(&mut FynixCtx<W>) -> Option<ElementId> + 'static`.
+pub trait BuildFn<W>:
+    Fn(&mut FynixCtx<W>) -> Option<ElementId> + 'static
+{
+}
+
+impl<W, F> BuildFn<W> for F where
+    F: Fn(&mut FynixCtx<W>) -> Option<ElementId> + 'static
+{
+}
 
 /// A watcher, stored as a component on its [`WatcherElement`] holder
 /// (see [`ElementTable::insert_component`]). The holder's
@@ -50,13 +62,12 @@ pub type BuildFn<W> = fn(&mut FynixCtx<W>) -> Option<ElementId>;
 /// of its own.
 ///
 /// [`ElementTable::insert_component`]: crate::element::table::ElementTable::insert_component
-#[derive(Debug)]
 pub struct Watcher<W: 'static> {
     /// Reports whether the watched source changed since the last
     /// flush, requiring a rebuild of [`WatcherElement::child`].
-    changed_fn: ChangedFn<W>,
+    changed: Changed<W>,
     /// Builds the replacement for [`WatcherElement::child`].
-    build_fn: BuildFn<W>,
+    build: Box<dyn BuildFn<W>>,
     /// Style scope active when the watcher was created. Restored on
     /// each rebuild so the subtree is styled like its first build.
     style_id: Option<StyleId>,
@@ -64,20 +75,20 @@ pub struct Watcher<W: 'static> {
 
 impl<W> Watcher<W> {
     pub(crate) fn new(
-        changed_fn: ChangedFn<W>,
-        build_fn: BuildFn<W>,
+        changed: impl ChangedFn<W>,
+        build: impl BuildFn<W>,
         style_id: Option<StyleId>,
     ) -> Self {
         Self {
-            changed_fn,
-            build_fn,
+            changed: Changed::new(changed),
+            build: Box::new(build),
             style_id,
         }
     }
 
     /// Returns `true` if the watched source changed.
     pub fn is_changed(&self, world: &W) -> bool {
-        (self.changed_fn)(world)
+        self.changed.is_changed(world)
     }
 
     /// Rebuilds the subtree under the [`WatcherElement`] at `id`:
@@ -109,7 +120,7 @@ impl<W> Watcher<W> {
         // any uncommitted style changes so they do not leak.
         let child = {
             let mut ctx = fynix.create_ctx(world, self.style_id);
-            (self.build_fn)(&mut ctx)
+            (self.build)(&mut ctx)
         };
         fynix.styles.clear_builder();
 
@@ -128,14 +139,6 @@ impl<W> Watcher<W> {
         // Mark the rebuilt subtree dirty so it is re-laid-out and
         // re-rendered.
         fynix.elements.mark_dirty(*id);
-    }
-}
-
-impl<W> Copy for Watcher<W> {}
-
-impl<W> Clone for Watcher<W> {
-    fn clone(&self) -> Self {
-        *self
     }
 }
 

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -528,16 +528,16 @@ impl Overlay {
     fn anchor_translation(
         side: Side,
         gap: f32,
-        cross: Align,
+        cross_align: Align,
         anchor_pos: Vec2,
         anchor_size: Size,
         child_size: Size,
     ) -> Vec2 {
-        let (main, cross_val) = match side {
+        let (main_offset, cross_offset) = match side {
             Side::Top => (
                 anchor_pos.y - child_size.height - gap,
                 Self::cross_align(
-                    cross,
+                    cross_align,
                     anchor_pos.x,
                     anchor_size.width,
                     child_size.width,
@@ -546,7 +546,7 @@ impl Overlay {
             Side::Bottom => (
                 anchor_pos.y + anchor_size.height + gap,
                 Self::cross_align(
-                    cross,
+                    cross_align,
                     anchor_pos.x,
                     anchor_size.width,
                     child_size.width,
@@ -554,7 +554,7 @@ impl Overlay {
             ),
             Side::Left => (
                 Self::cross_align(
-                    cross,
+                    cross_align,
                     anchor_pos.y,
                     anchor_size.height,
                     child_size.height,
@@ -563,7 +563,7 @@ impl Overlay {
             ),
             Side::Right => (
                 Self::cross_align(
-                    cross,
+                    cross_align,
                     anchor_pos.y,
                     anchor_size.height,
                     child_size.height,
@@ -572,8 +572,12 @@ impl Overlay {
             ),
         };
         match side {
-            Side::Top | Side::Bottom => Vec2::new(cross_val, main),
-            Side::Left | Side::Right => Vec2::new(main, cross_val),
+            Side::Top | Side::Bottom => {
+                Vec2::new(cross_offset, main_offset)
+            }
+            Side::Left | Side::Right => {
+                Vec2::new(main_offset, cross_offset)
+            }
         }
     }
 
@@ -585,67 +589,70 @@ impl Overlay {
     ) -> Option<(Vec2, Size)> {
         let anchor_node = nodes.get_node(&anchor_id)?;
         let size = anchor_node.size;
-        let mut pos = anchor_node.translation;
-        let mut current = anchor_node.parent_id?;
+        let mut accumulated_pos = anchor_node.translation;
+        let mut current_id = anchor_node.parent_id?;
         loop {
-            if current == overlay_id {
-                return Some((pos, size));
+            if current_id == overlay_id {
+                return Some((accumulated_pos, size));
             }
-            let node = nodes.get_node(&current)?;
-            pos = pos + node.translation;
-            current = node.parent_id?;
+            let node = nodes.get_node(&current_id)?;
+            accumulated_pos = accumulated_pos + node.translation;
+            current_id = node.parent_id?;
         }
     }
 
     fn resolve_anchor_offset(
         &self,
-        pos: Vec2,
+        anchor_pos: Vec2,
         anchor_size: Size,
-        ov_size: Size,
+        overlay_size: Size,
         viewport: Option<Size>,
     ) -> Vec2 {
-        let cross = match self.side {
+        let cross_align = match self.side {
             Side::Top | Side::Bottom => self.h_align,
             Side::Left | Side::Right => self.v_align,
         };
-        let t = Self::anchor_translation(
+        let translation = Self::anchor_translation(
             self.side,
             self.gap,
-            cross,
-            pos,
+            cross_align,
+            anchor_pos,
             anchor_size,
-            ov_size,
+            overlay_size,
         ) + self.offset;
-        let Some(vp) = viewport else {
-            return t;
+        let Some(viewport_size) = viewport else {
+            return translation;
         };
-        let overflows = |p: Vec2, sz: Size| -> bool {
-            p.x < 0.0
-                || p.y < 0.0
-                || p.x + sz.width > vp.width
-                || p.y + sz.height > vp.height
+        let overflows = |pos: Vec2, child_size: Size| -> bool {
+            pos.x < 0.0
+                || pos.y < 0.0
+                || pos.x + child_size.width > viewport_size.width
+                || pos.y + child_size.height > viewport_size.height
         };
-        if !overflows(t, ov_size) {
-            return t;
+        if !overflows(translation, overlay_size) {
+            return translation;
         }
-        let flipped = Self::anchor_translation(
+        let flipped_translation = Self::anchor_translation(
             self.side.opposite(),
             self.gap,
-            cross,
-            pos,
+            cross_align,
+            anchor_pos,
             anchor_size,
-            ov_size,
+            overlay_size,
         ) + self.offset;
-        let candidate = if overflows(flipped, ov_size) {
-            t
-        } else {
-            flipped
-        };
-        let max_x = (vp.width - ov_size.width).max(0.0);
-        let max_y = (vp.height - ov_size.height).max(0.0);
+        let best_candidate =
+            if overflows(flipped_translation, overlay_size) {
+                translation
+            } else {
+                flipped_translation
+            };
+        let clamp_x =
+            (viewport_size.width - overlay_size.width).max(0.0);
+        let clamp_y =
+            (viewport_size.height - overlay_size.height).max(0.0);
         Vec2::new(
-            candidate.x.max(0.0).min(max_x),
-            candidate.y.max(0.0).min(max_y),
+            best_candidate.x.max(0.0).min(clamp_x),
+            best_candidate.y.max(0.0).min(clamp_y),
         )
     }
 }
@@ -670,9 +677,9 @@ impl ElementBuild for Overlay {
         let content_size = self
             .content
             .as_ref()
-            .map(|c| {
-                nodes.set_translation(c, Vec2::ZERO);
-                nodes.get_size(c)
+            .map(|content_id| {
+                nodes.set_translation(content_id, Vec2::ZERO);
+                nodes.get_size(content_id)
             })
             .unwrap_or(Size::ZERO);
 
@@ -684,9 +691,9 @@ impl ElementBuild for Overlay {
 
         let mut result = content_size;
 
-        let anchor_data = self
-            .anchor
-            .and_then(|a| self.compute_anchor_pos(a, *id, nodes));
+        let anchor_data = self.anchor.and_then(|anchor_id| {
+            self.compute_anchor_pos(anchor_id, *id, nodes)
+        });
         let has_anchor = anchor_data.is_some();
         let viewport = if self.flip && has_anchor {
             Some(constraint.max)
@@ -694,48 +701,60 @@ impl ElementBuild for Overlay {
             None
         };
 
-        for ov in &self.overlays {
-            let ov_size = nodes.get_size(ov);
-            let t = if let Some((pos, size)) = anchor_data {
+        for overlay_id in &self.overlays {
+            let overlay_size = nodes.get_size(overlay_id);
+            let translation = if let Some((pos, size)) = anchor_data {
                 self.resolve_anchor_offset(
-                    pos, size, ov_size, viewport,
+                    pos,
+                    size,
+                    overlay_size,
+                    viewport,
                 )
             } else {
-                let x = match self.h_align {
+                let align_x = match self.h_align {
                     Align::Start => 0.0,
                     Align::Center => {
-                        (content_size.width - ov_size.width) / 2.0
-                    }
-                    Align::End => content_size.width - ov_size.width,
-                };
-                let y = match self.v_align {
-                    Align::Start => 0.0,
-                    Align::Center => {
-                        (content_size.height - ov_size.height) / 2.0
+                        (content_size.width - overlay_size.width)
+                            / 2.0
                     }
                     Align::End => {
-                        content_size.height - ov_size.height
+                        content_size.width - overlay_size.width
                     }
                 };
-                let mut p = Vec2::new(x, y) + self.offset;
+                let align_y = match self.v_align {
+                    Align::Start => 0.0,
+                    Align::Center => {
+                        (content_size.height - overlay_size.height)
+                            / 2.0
+                    }
+                    Align::End => {
+                        content_size.height - overlay_size.height
+                    }
+                };
+                let mut pos =
+                    Vec2::new(align_x, align_y) + self.offset;
                 if self.clip {
-                    let max_x =
-                        (content_size.width - ov_size.width).max(0.0);
-                    let max_y = (content_size.height
-                        - ov_size.height)
+                    let clamp_x = (content_size.width
+                        - overlay_size.width)
                         .max(0.0);
-                    p = Vec2::new(
-                        p.x.max(0.0).min(max_x),
-                        p.y.max(0.0).min(max_y),
+                    let clamp_y = (content_size.height
+                        - overlay_size.height)
+                        .max(0.0);
+                    pos = Vec2::new(
+                        pos.x.max(0.0).min(clamp_x),
+                        pos.y.max(0.0).min(clamp_y),
                     );
                 }
-                p
+                pos
             };
-            nodes.set_translation(ov, t);
+            nodes.set_translation(overlay_id, translation);
             if !has_anchor && !self.clip {
-                result.width = result.width.max(t.x + ov_size.width);
-                result.height =
-                    result.height.max(t.y + ov_size.height);
+                result.width = result
+                    .width
+                    .max(translation.x + overlay_size.width);
+                result.height = result
+                    .height
+                    .max(translation.y + overlay_size.height);
             }
         }
 

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -678,7 +678,7 @@ impl ElementBuild for Overlay {
         let content_size = constraint.constrain(content_size);
 
         if self.overlays.is_empty() {
-            return constraint.constrain(content_size);
+            return content_size;
         }
 
         let mut result = content_size;

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -602,7 +602,7 @@ impl Overlay {
         pos: Vec2,
         anchor_size: Size,
         ov_size: Size,
-        viewport: Option<Viewport>,
+        viewport: Option<Size>,
     ) -> Vec2 {
         let cross = match self.side {
             Side::Top | Side::Bottom => self.h_align,
@@ -689,7 +689,7 @@ impl ElementBuild for Overlay {
             .and_then(|a| self.compute_anchor_pos(a, *id, nodes));
         let has_anchor = anchor_data.is_some();
         let viewport = if self.flip && has_anchor {
-            nodes.get_resource::<Viewport>().copied()
+            Some(constraint.max)
         } else {
             None
         };
@@ -741,14 +741,6 @@ impl ElementBuild for Overlay {
 
         constraint.constrain(result)
     }
-}
-
-/// Viewport bounds for overflow detection and flip behavior.
-/// Stored as a resource; read automatically by Overlay during build.
-#[derive(Clone, Copy, Debug)]
-pub struct Viewport {
-    pub width: f32,
-    pub height: f32,
 }
 
 #[derive(Default, Clone)]

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -476,8 +476,12 @@ pub enum Align {
     End,
 }
 
-#[derive(Init, Clone, Copy, Debug)]
-pub struct OverlayStyle {
+#[derive(Init, Debug, Clone)]
+pub struct Overlay {
+    #[init(None)]
+    pub content: Option<ElementId>,
+    #[init(Default::default())]
+    pub overlays: Vec<ElementId>,
     #[init(Align::Start)]
     pub h_align: Align,
     #[init(Align::Center)]
@@ -494,16 +498,6 @@ pub struct OverlayStyle {
     pub gap: f32,
     #[init(true)]
     pub flip: bool,
-}
-
-#[derive(Init, Debug, Clone)]
-pub struct Overlay {
-    #[init(None)]
-    pub content: Option<ElementId>,
-    #[init(Default::default())]
-    pub overlays: Vec<ElementId>,
-    #[init(OverlayStyle::init())]
-    pub style: OverlayStyle,
 }
 
 impl Overlay {
@@ -552,22 +546,21 @@ impl ElementBuild for Overlay {
 
         let mut result = content_size;
 
-        let clip = self.style.clip;
-        let side = self.style.side;
-        let gap = self.style.gap;
-        let offset = self.style.offset;
-        let h_align = self.style.h_align;
-        let v_align = self.style.v_align;
+        let clip = self.clip;
+        let side = self.side;
+        let gap = self.gap;
+        let offset = self.offset;
+        let h_align = self.h_align;
+        let v_align = self.v_align;
         let cross = match side {
             Side::Top | Side::Bottom => h_align,
             Side::Left | Side::Right => v_align,
         };
         let anchor_data = self
-            .style
             .anchor
             .and_then(|a| compute_anchor_pos(a, *id, nodes));
         let has_anchor = anchor_data.is_some();
-        let viewport = if self.style.flip && has_anchor {
+        let viewport = if self.flip && has_anchor {
             nodes.get_resource::<Viewport>().copied()
         } else {
             None
@@ -884,42 +877,25 @@ impl Default for OverlayComposer {
 }
 
 impl<W> Composer<W> for OverlayComposer {
-    type Style = OverlayStyle;
+    type Style = Overlay;
     type Element = Overlay;
 
     fn compose(
         self,
-        mut style: Self::Style,
+        style: Self::Style,
         ctx: &mut FynixCtx<'_, '_, W>,
     ) -> ElementHandle<Overlay> {
-        if let Some(a) = self.anchor {
-            style.anchor = Some(a);
-        }
-        if let Some(s) = self.side {
-            style.side = s;
-        }
-        if let Some(g) = self.gap {
-            style.gap = g;
-        }
-        if let Some(h) = self.h_align {
-            style.h_align = h;
-        }
-        if let Some(v) = self.v_align {
-            style.v_align = v;
-        }
-        if let Some(o) = self.offset {
-            style.offset = o;
-        }
-        if let Some(c) = self.clip {
-            style.clip = c;
-        }
-        if let Some(f) = self.flip {
-            style.flip = f;
-        }
-        ctx.add_with::<Overlay>(|o, _| {
+        ctx.add_with::<Overlay>(move |o, _| {
             o.content = self.content;
             o.overlays = self.overlays;
-            o.style = style;
+            o.h_align = self.h_align.unwrap_or(style.h_align);
+            o.v_align = self.v_align.unwrap_or(style.v_align);
+            o.offset = self.offset.unwrap_or(style.offset);
+            o.clip = self.clip.unwrap_or(style.clip);
+            o.anchor = self.anchor.or(style.anchor);
+            o.side = self.side.unwrap_or(style.side);
+            o.gap = self.gap.unwrap_or(style.gap);
+            o.flip = self.flip.unwrap_or(style.flip);
         })
         .handle()
     }

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -671,28 +671,6 @@ fn resolve_anchor_offset(
     )
 }
 
-fn walk_to_root(
-    start: Option<ElementId>,
-    nodes: &ElementNodes,
-) -> Vec2 {
-    let mut pos = Vec2::ZERO;
-    let mut current = match start {
-        Some(id) => id,
-        None => return Vec2::ZERO,
-    };
-    loop {
-        let Some(node) = nodes.get_node(&current) else {
-            break;
-        };
-        pos = pos + node.translation;
-        match node.parent_id {
-            Some(parent_id) => current = parent_id,
-            None => break,
-        }
-    }
-    pos
-}
-
 fn compute_anchor_pos(
     anchor_id: ElementId,
     overlay_id: ElementId,
@@ -700,16 +678,16 @@ fn compute_anchor_pos(
 ) -> Option<(Vec2, Size)> {
     let anchor_node = nodes.get_node(&anchor_id)?;
     let size = anchor_node.size;
-    let anchor_root = anchor_node.translation
-        + walk_to_root(anchor_node.parent_id, nodes);
-    let overlay_root = walk_to_root(Some(overlay_id), nodes);
-    Some((
-        Vec2::new(
-            anchor_root.x - overlay_root.x,
-            anchor_root.y - overlay_root.y,
-        ),
-        size,
-    ))
+    let mut pos = anchor_node.translation;
+    let mut current = anchor_node.parent_id?;
+    loop {
+        if current == overlay_id {
+            return Some((pos, size));
+        }
+        let node = nodes.get_node(&current)?;
+        pos = pos + node.translation;
+        current = node.parent_id?;
+    }
 }
 
 fn anchor_translation(

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -520,26 +520,7 @@ impl Overlay {
 
 impl ElementChildren for Overlay {
     fn children(&self) -> impl IntoIterator<Item = &ElementId> {
-        OverlayChildIter {
-            content: self.content.as_ref(),
-            overlays: self.overlays.iter(),
-        }
-    }
-}
-
-struct OverlayChildIter<'a> {
-    content: Option<&'a ElementId>,
-    overlays: core::slice::Iter<'a, ElementId>,
-}
-
-impl<'a> Iterator for OverlayChildIter<'a> {
-    type Item = &'a ElementId;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some(id) = self.content.take() {
-            return Some(id);
-        }
-        self.overlays.next()
+        self.content.iter().chain(self.overlays.iter())
     }
 }
 

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -5,7 +5,9 @@ extern crate alloc;
 use alloc::string::String;
 use alloc::vec::Vec;
 
+use fynix::RectNodes;
 use fynix::element::layout::ElementNodes;
+use fynix::element::storage::ElementHandle;
 use fynix::element::table::RenderElementTable;
 use fynix::imaging::kurbo::{Affine, Stroke};
 use fynix::imaging::peniko::{Brush, BrushRef, Color, Fill, Style};
@@ -260,6 +262,80 @@ impl ElementBuild for Button {
     }
 }
 
+#[derive(Init, Element)]
+pub struct Frame {
+    pub fill: Brush,
+    pub corner_radius: f64,
+    pub top: f32,
+    pub right: f32,
+    pub bottom: f32,
+    pub left: f32,
+    #[elem(children)]
+    pub child: Option<ElementId>,
+}
+
+impl Frame {
+    pub fn set_child(&mut self, id: impl Into<ElementId>) {
+        self.child = Some(id.into());
+    }
+}
+
+impl ElementBuild for Frame {
+    fn constrain(&self, parent_constraint: Constraint) -> Constraint {
+        let h = self.left + self.right;
+        let v = self.top + self.bottom;
+        Constraint {
+            min: Size::ZERO,
+            max: Size::new(
+                (parent_constraint.max.width - h).max(0.0),
+                (parent_constraint.max.height - v).max(0.0),
+            ),
+        }
+    }
+
+    fn build(
+        &self,
+        _id: &ElementId,
+        constraint: Constraint,
+        nodes: &mut ElementNodes,
+    ) -> Size {
+        let child_size = self
+            .child
+            .as_ref()
+            .map(|id| {
+                nodes.set_translation(
+                    id,
+                    Vec2::new(self.left, self.top),
+                );
+                nodes.get_size(id)
+            })
+            .unwrap_or_default();
+        constraint.constrain(Size::new(
+            child_size.width + self.left + self.right,
+            child_size.height + self.top + self.bottom,
+        ))
+    }
+
+    fn render(
+        &self,
+        id: &ElementId,
+        painter: &mut dyn PaintSink,
+        table: RenderElementTable,
+    ) {
+        let Some(node) = table.node(id) else { return };
+        let pos = node.world_translation;
+        let size = node.size;
+        let shape = kurbo::RoundedRect::new(
+            pos.x as f64,
+            pos.y as f64,
+            (pos.x + size.width) as f64,
+            (pos.y + size.height) as f64,
+            self.corner_radius,
+        );
+        painter.fill(FillRef::new(shape, &self.fill));
+    }
+}
+
 #[derive(Init, Element, Debug, Clone)]
 pub struct Label {
     pub text: String,
@@ -370,6 +446,510 @@ impl ElementBuild for Label {
             Affine::translate((pos.x as f64, pos.y as f64));
         replay_transformed(scene, painter, transform);
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum Side {
+    #[default]
+    Bottom,
+    Top,
+    Left,
+    Right,
+}
+
+impl Side {
+    fn opposite(self) -> Self {
+        match self {
+            Self::Bottom => Self::Top,
+            Self::Top => Self::Bottom,
+            Self::Left => Self::Right,
+            Self::Right => Self::Left,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum Align {
+    #[default]
+    Center,
+    Start,
+    End,
+}
+
+#[derive(Init, Clone, Copy, Debug)]
+pub struct OverlayStyle {
+    #[init(Align::Start)]
+    pub h_align: Align,
+    #[init(Align::Center)]
+    pub v_align: Align,
+    #[init(Vec2::ZERO)]
+    pub offset: Vec2,
+    #[init(false)]
+    pub clip: bool,
+    #[init(None)]
+    pub anchor: Option<ElementId>,
+    #[init(Side::Bottom)]
+    pub side: Side,
+    #[init(0.0)]
+    pub gap: f32,
+    #[init(true)]
+    pub flip: bool,
+}
+
+#[derive(Init, Debug, Clone)]
+pub struct Overlay {
+    #[init(None)]
+    pub content: Option<ElementId>,
+    #[init(Default::default())]
+    pub overlays: Vec<ElementId>,
+    #[init(OverlayStyle::init())]
+    pub style: OverlayStyle,
+}
+
+impl Overlay {
+    pub fn content(mut self, id: impl Into<ElementId>) -> Self {
+        self.content = Some(id.into());
+        self
+    }
+
+    pub fn overlay(mut self, id: impl Into<ElementId>) -> Self {
+        self.overlays.push(id.into());
+        self
+    }
+}
+
+impl ElementChildren for Overlay {
+    fn children(&self) -> impl IntoIterator<Item = &ElementId> {
+        OverlayChildIter {
+            content: self.content.as_ref(),
+            overlays: self.overlays.iter(),
+        }
+    }
+}
+
+struct OverlayChildIter<'a> {
+    content: Option<&'a ElementId>,
+    overlays: core::slice::Iter<'a, ElementId>,
+}
+
+impl<'a> Iterator for OverlayChildIter<'a> {
+    type Item = &'a ElementId;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(id) = self.content.take() {
+            return Some(id);
+        }
+        self.overlays.next()
+    }
+}
+
+impl ElementBuild for Overlay {
+    fn constrain(&self, parent: Constraint) -> Constraint {
+        parent
+    }
+
+    fn build(
+        &self,
+        id: &ElementId,
+        constraint: Constraint,
+        nodes: &mut ElementNodes,
+    ) -> Size {
+        let content_size = self
+            .content
+            .as_ref()
+            .map(|c| {
+                nodes.set_translation(c, Vec2::ZERO);
+                nodes.get_size(c)
+            })
+            .unwrap_or(Size::ZERO);
+
+        let content_size = constraint.constrain(content_size);
+
+        if self.overlays.is_empty() {
+            return constraint.constrain(content_size);
+        }
+
+        let mut result = content_size;
+
+        let clip = self.style.clip;
+        let side = self.style.side;
+        let gap = self.style.gap;
+        let offset = self.style.offset;
+        let h_align = self.style.h_align;
+        let v_align = self.style.v_align;
+        let cross = match side {
+            Side::Top | Side::Bottom => h_align,
+            Side::Left | Side::Right => v_align,
+        };
+        let anchor_data = self
+            .style
+            .anchor
+            .and_then(|a| compute_anchor_pos(a, *id, nodes));
+        let has_anchor = anchor_data.is_some();
+        let viewport = if self.style.flip && has_anchor {
+            nodes.get_resource::<Viewport>().copied()
+        } else {
+            None
+        };
+
+        for ov in &self.overlays {
+            let ov_size = nodes.get_size(ov);
+            let t = if let Some((pos, size)) = anchor_data {
+                resolve_anchor_offset(
+                    side, cross, gap, offset, pos, size, ov_size,
+                    viewport,
+                )
+            } else {
+                let p = alignment_offset(
+                    h_align,
+                    v_align,
+                    content_size,
+                    ov_size,
+                ) + offset;
+                if clip {
+                    clamp_to_bounds(p, ov_size, content_size)
+                } else {
+                    p
+                }
+            };
+            nodes.set_translation(ov, t);
+            if !has_anchor && !clip {
+                result.width = result.width.max(t.x + ov_size.width);
+                result.height =
+                    result.height.max(t.y + ov_size.height);
+            }
+        }
+
+        constraint.constrain(result)
+    }
+}
+
+fn alignment_offset(
+    h_align: Align,
+    v_align: Align,
+    content: Size,
+    child: Size,
+) -> Vec2 {
+    let x = match h_align {
+        Align::Start => 0.0,
+        Align::Center => (content.width - child.width) / 2.0,
+        Align::End => content.width - child.width,
+    };
+    let y = match v_align {
+        Align::Start => 0.0,
+        Align::Center => (content.height - child.height) / 2.0,
+        Align::End => content.height - child.height,
+    };
+    Vec2::new(x, y)
+}
+
+fn clamp_to_bounds(
+    pos: Vec2,
+    child_size: Size,
+    bounds: Size,
+) -> Vec2 {
+    let max_x = (bounds.width - child_size.width).max(0.0);
+    let max_y = (bounds.height - child_size.height).max(0.0);
+    Vec2::new(pos.x.max(0.0).min(max_x), pos.y.max(0.0).min(max_y))
+}
+
+fn resolve_anchor_offset(
+    side: Side,
+    cross: Align,
+    gap: f32,
+    offset: Vec2,
+    pos: Vec2,
+    anchor_size: Size,
+    ov_size: Size,
+    viewport: Option<Viewport>,
+) -> Vec2 {
+    let t = anchor_translation(
+        side,
+        cross,
+        gap,
+        pos,
+        anchor_size,
+        ov_size,
+    ) + offset;
+    let Some(vp) = viewport else {
+        return t;
+    };
+    if !anchor_overflows(t, ov_size, &vp) {
+        return t;
+    }
+    let flipped = anchor_translation(
+        side.opposite(),
+        cross,
+        gap,
+        pos,
+        anchor_size,
+        ov_size,
+    ) + offset;
+    let candidate = if anchor_overflows(flipped, ov_size, &vp) {
+        t
+    } else {
+        flipped
+    };
+    clamp_to_bounds(
+        candidate,
+        ov_size,
+        Size::new(vp.width, vp.height),
+    )
+}
+
+fn walk_to_root(
+    start: Option<ElementId>,
+    nodes: &ElementNodes,
+) -> Vec2 {
+    let mut pos = Vec2::ZERO;
+    let mut current = match start {
+        Some(id) => id,
+        None => return Vec2::ZERO,
+    };
+    loop {
+        let Some(node) = nodes.get_node(&current) else {
+            break;
+        };
+        pos = pos + node.translation;
+        match node.parent_id {
+            Some(parent_id) => current = parent_id,
+            None => break,
+        }
+    }
+    pos
+}
+
+fn compute_anchor_pos(
+    anchor_id: ElementId,
+    overlay_id: ElementId,
+    nodes: &ElementNodes,
+) -> Option<(Vec2, Size)> {
+    let anchor_node = nodes.get_node(&anchor_id)?;
+    let size = anchor_node.size;
+    let anchor_root = anchor_node.translation
+        + walk_to_root(anchor_node.parent_id, nodes);
+    let overlay_root = walk_to_root(Some(overlay_id), nodes);
+    Some((
+        Vec2::new(
+            anchor_root.x - overlay_root.x,
+            anchor_root.y - overlay_root.y,
+        ),
+        size,
+    ))
+}
+
+fn anchor_translation(
+    side: Side,
+    cross: Align,
+    gap: f32,
+    anchor_pos: Vec2,
+    anchor_size: Size,
+    child_size: Size,
+) -> Vec2 {
+    let (main, cross_val) = match side {
+        Side::Top => (
+            anchor_pos.y - child_size.height - gap,
+            cross_align(
+                cross,
+                anchor_pos.x,
+                anchor_size.width,
+                child_size.width,
+            ),
+        ),
+        Side::Bottom => (
+            anchor_pos.y + anchor_size.height + gap,
+            cross_align(
+                cross,
+                anchor_pos.x,
+                anchor_size.width,
+                child_size.width,
+            ),
+        ),
+        Side::Left => (
+            cross_align(
+                cross,
+                anchor_pos.y,
+                anchor_size.height,
+                child_size.height,
+            ),
+            anchor_pos.x - child_size.width - gap,
+        ),
+        Side::Right => (
+            cross_align(
+                cross,
+                anchor_pos.y,
+                anchor_size.height,
+                child_size.height,
+            ),
+            anchor_pos.x + anchor_size.width + gap,
+        ),
+    };
+    match side {
+        Side::Top | Side::Bottom => Vec2::new(cross_val, main),
+        Side::Left | Side::Right => Vec2::new(main, cross_val),
+    }
+}
+
+fn cross_align(
+    align: Align,
+    anchor_start: f32,
+    anchor_span: f32,
+    child_span: f32,
+) -> f32 {
+    match align {
+        Align::Start => anchor_start,
+        Align::Center => {
+            anchor_start + (anchor_span - child_span) / 2.0
+        }
+        Align::End => anchor_start + anchor_span - child_span,
+    }
+}
+
+fn anchor_overflows(
+    pos: Vec2,
+    size: Size,
+    viewport: &Viewport,
+) -> bool {
+    pos.x < 0.0
+        || pos.y < 0.0
+        || pos.x + size.width > viewport.width
+        || pos.y + size.height > viewport.height
+}
+
+pub struct OverlayComposer {
+    content: Option<ElementId>,
+    overlays: Vec<ElementId>,
+    anchor: Option<ElementId>,
+    side: Option<Side>,
+    gap: Option<f32>,
+    h_align: Option<Align>,
+    v_align: Option<Align>,
+    offset: Option<Vec2>,
+    clip: Option<bool>,
+    flip: Option<bool>,
+}
+
+impl OverlayComposer {
+    pub fn new() -> Self {
+        Self {
+            content: None,
+            overlays: Vec::new(),
+            anchor: None,
+            side: None,
+            gap: None,
+            h_align: None,
+            v_align: None,
+            offset: None,
+            clip: None,
+            flip: None,
+        }
+    }
+
+    pub fn content(mut self, id: impl Into<ElementId>) -> Self {
+        self.content = Some(id.into());
+        self
+    }
+
+    pub fn overlay(mut self, id: impl Into<ElementId>) -> Self {
+        self.overlays.push(id.into());
+        self
+    }
+
+    pub fn anchor(mut self, id: impl Into<ElementId>) -> Self {
+        self.anchor = Some(id.into());
+        self
+    }
+
+    pub fn side(mut self, s: Side) -> Self {
+        self.side = Some(s);
+        self
+    }
+
+    pub fn gap(mut self, g: f32) -> Self {
+        self.gap = Some(g);
+        self
+    }
+
+    pub fn h_align(mut self, a: Align) -> Self {
+        self.h_align = Some(a);
+        self
+    }
+
+    pub fn v_align(mut self, a: Align) -> Self {
+        self.v_align = Some(a);
+        self
+    }
+
+    pub fn offset(mut self, v: Vec2) -> Self {
+        self.offset = Some(v);
+        self
+    }
+
+    pub fn clip(mut self, b: bool) -> Self {
+        self.clip = Some(b);
+        self
+    }
+
+    pub fn flip(mut self, b: bool) -> Self {
+        self.flip = Some(b);
+        self
+    }
+}
+
+impl Default for OverlayComposer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<W> Composer<W> for OverlayComposer {
+    type Style = OverlayStyle;
+    type Element = Overlay;
+
+    fn compose(
+        self,
+        mut style: Self::Style,
+        ctx: &mut FynixCtx<'_, '_, W>,
+    ) -> ElementHandle<Overlay> {
+        if let Some(a) = self.anchor {
+            style.anchor = Some(a);
+        }
+        if let Some(s) = self.side {
+            style.side = s;
+        }
+        if let Some(g) = self.gap {
+            style.gap = g;
+        }
+        if let Some(h) = self.h_align {
+            style.h_align = h;
+        }
+        if let Some(v) = self.v_align {
+            style.v_align = v;
+        }
+        if let Some(o) = self.offset {
+            style.offset = o;
+        }
+        if let Some(c) = self.clip {
+            style.clip = c;
+        }
+        if let Some(f) = self.flip {
+            style.flip = f;
+        }
+        ctx.add_with::<Overlay>(|o, _| {
+            o.content = self.content;
+            o.overlays = self.overlays;
+            o.style = style;
+        })
+        .handle()
+    }
+}
+
+/// Viewport bounds for overflow detection and flip behavior.
+/// Stored as a resource; read automatically by Overlay during build.
+#[derive(Clone, Copy, Debug)]
+pub struct Viewport {
+    pub width: f32,
+    pub height: f32,
 }
 
 #[derive(Default, Clone)]

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -533,51 +533,43 @@ impl Overlay {
         anchor_size: Size,
         child_size: Size,
     ) -> Vec2 {
-        let (main_offset, cross_offset) = match side {
-            Side::Top => (
-                anchor_pos.y - child_size.height - gap,
-                Self::cross_align(
-                    cross_align,
-                    anchor_pos.x,
-                    anchor_size.width,
-                    child_size.width,
-                ),
-            ),
-            Side::Bottom => (
-                anchor_pos.y + anchor_size.height + gap,
-                Self::cross_align(
-                    cross_align,
-                    anchor_pos.x,
-                    anchor_size.width,
-                    child_size.width,
-                ),
-            ),
-            Side::Left => (
-                Self::cross_align(
-                    cross_align,
-                    anchor_pos.y,
-                    anchor_size.height,
-                    child_size.height,
-                ),
-                anchor_pos.x - child_size.width - gap,
-            ),
-            Side::Right => (
-                Self::cross_align(
-                    cross_align,
-                    anchor_pos.y,
-                    anchor_size.height,
-                    child_size.height,
-                ),
-                anchor_pos.x + anchor_size.width + gap,
-            ),
-        };
         match side {
-            Side::Top | Side::Bottom => {
-                Vec2::new(cross_offset, main_offset)
-            }
-            Side::Left | Side::Right => {
-                Vec2::new(main_offset, cross_offset)
-            }
+            Side::Top => Vec2::new(
+                Self::cross_align(
+                    cross_align,
+                    anchor_pos.x,
+                    anchor_size.width,
+                    child_size.width,
+                ),
+                anchor_pos.y - child_size.height - gap,
+            ),
+            Side::Bottom => Vec2::new(
+                Self::cross_align(
+                    cross_align,
+                    anchor_pos.x,
+                    anchor_size.width,
+                    child_size.width,
+                ),
+                anchor_pos.y + anchor_size.height + gap,
+            ),
+            Side::Left => Vec2::new(
+                anchor_pos.x - child_size.width - gap,
+                Self::cross_align(
+                    cross_align,
+                    anchor_pos.y,
+                    anchor_size.height,
+                    child_size.height,
+                ),
+            ),
+            Side::Right => Vec2::new(
+                anchor_pos.x + anchor_size.width + gap,
+                Self::cross_align(
+                    cross_align,
+                    anchor_pos.y,
+                    anchor_size.height,
+                    child_size.height,
+                ),
+            ),
         }
     }
 

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -647,6 +647,25 @@ impl Overlay {
             best_candidate.y.max(0.0).min(clamp_y),
         )
     }
+
+    /// Walks from `from_id` up to the root node. Returns the
+    /// accumulated translation (world position of `from_id`) and
+    /// the root node's size (the viewport).
+    fn walk_to_root(
+        from_id: ElementId,
+        nodes: &ElementNodes,
+    ) -> Option<(Vec2, Size)> {
+        let mut offset = Vec2::ZERO;
+        let mut current_id = from_id;
+        loop {
+            let node = nodes.get_node(&current_id)?;
+            offset = offset + node.translation;
+            match node.parent_id {
+                Some(parent) => current_id = parent,
+                None => return Some((offset, node.size)),
+            }
+        }
+    }
 }
 
 impl ElementChildren for Overlay {
@@ -687,8 +706,15 @@ impl ElementBuild for Overlay {
             self.compute_anchor_pos(anchor_id, *id, nodes)
         });
         let has_anchor = anchor_data.is_some();
+        let (overlay_root_offset, root_viewport) =
+            if self.flip && has_anchor {
+                Self::walk_to_root(*id, nodes)
+                    .unwrap_or((Vec2::ZERO, Size::ZERO))
+            } else {
+                (Vec2::ZERO, Size::ZERO)
+            };
         let viewport = if self.flip && has_anchor {
-            Some(constraint.max)
+            Some(root_viewport)
         } else {
             None
         };
@@ -696,11 +722,15 @@ impl ElementBuild for Overlay {
         for overlay_id in &self.overlays {
             let overlay_size = nodes.get_size(overlay_id);
             let translation = if let Some((pos, size)) = anchor_data {
-                self.resolve_anchor_offset(
-                    pos,
+                let root_translation = self.resolve_anchor_offset(
+                    pos + overlay_root_offset,
                     size,
                     overlay_size,
                     viewport,
+                );
+                Vec2::new(
+                    root_translation.x - overlay_root_offset.x,
+                    root_translation.y - overlay_root_offset.y,
                 )
             } else {
                 let align_x = Self::cross_align(

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -7,7 +7,6 @@ use alloc::vec::Vec;
 
 use fynix::RectNodes;
 use fynix::element::layout::ElementNodes;
-use fynix::element::storage::ElementHandle;
 use fynix::element::table::RenderElementTable;
 use fynix::imaging::kurbo::{Affine, Stroke};
 use fynix::imaging::peniko::{Brush, BrushRef, Color, Fill, Style};
@@ -510,6 +509,145 @@ impl Overlay {
         self.overlays.push(id.into());
         self
     }
+
+    fn cross_align(
+        align: Align,
+        anchor_start: f32,
+        anchor_span: f32,
+        child_span: f32,
+    ) -> f32 {
+        match align {
+            Align::Start => anchor_start,
+            Align::Center => {
+                anchor_start + (anchor_span - child_span) / 2.0
+            }
+            Align::End => anchor_start + anchor_span - child_span,
+        }
+    }
+
+    fn anchor_translation(
+        side: Side,
+        gap: f32,
+        cross: Align,
+        anchor_pos: Vec2,
+        anchor_size: Size,
+        child_size: Size,
+    ) -> Vec2 {
+        let (main, cross_val) = match side {
+            Side::Top => (
+                anchor_pos.y - child_size.height - gap,
+                Self::cross_align(
+                    cross,
+                    anchor_pos.x,
+                    anchor_size.width,
+                    child_size.width,
+                ),
+            ),
+            Side::Bottom => (
+                anchor_pos.y + anchor_size.height + gap,
+                Self::cross_align(
+                    cross,
+                    anchor_pos.x,
+                    anchor_size.width,
+                    child_size.width,
+                ),
+            ),
+            Side::Left => (
+                Self::cross_align(
+                    cross,
+                    anchor_pos.y,
+                    anchor_size.height,
+                    child_size.height,
+                ),
+                anchor_pos.x - child_size.width - gap,
+            ),
+            Side::Right => (
+                Self::cross_align(
+                    cross,
+                    anchor_pos.y,
+                    anchor_size.height,
+                    child_size.height,
+                ),
+                anchor_pos.x + anchor_size.width + gap,
+            ),
+        };
+        match side {
+            Side::Top | Side::Bottom => Vec2::new(cross_val, main),
+            Side::Left | Side::Right => Vec2::new(main, cross_val),
+        }
+    }
+
+    fn compute_anchor_pos(
+        &self,
+        anchor_id: ElementId,
+        overlay_id: ElementId,
+        nodes: &ElementNodes,
+    ) -> Option<(Vec2, Size)> {
+        let anchor_node = nodes.get_node(&anchor_id)?;
+        let size = anchor_node.size;
+        let mut pos = anchor_node.translation;
+        let mut current = anchor_node.parent_id?;
+        loop {
+            if current == overlay_id {
+                return Some((pos, size));
+            }
+            let node = nodes.get_node(&current)?;
+            pos = pos + node.translation;
+            current = node.parent_id?;
+        }
+    }
+
+    fn resolve_anchor_offset(
+        &self,
+        pos: Vec2,
+        anchor_size: Size,
+        ov_size: Size,
+        viewport: Option<Viewport>,
+    ) -> Vec2 {
+        let cross = match self.side {
+            Side::Top | Side::Bottom => self.h_align,
+            Side::Left | Side::Right => self.v_align,
+        };
+        let t = Self::anchor_translation(
+            self.side,
+            self.gap,
+            cross,
+            pos,
+            anchor_size,
+            ov_size,
+        ) + self.offset;
+        let Some(vp) = viewport else {
+            return t;
+        };
+        let overflows = |p: Vec2, sz: Size| -> bool {
+            p.x < 0.0
+                || p.y < 0.0
+                || p.x + sz.width > vp.width
+                || p.y + sz.height > vp.height
+        };
+        if !overflows(t, ov_size) {
+            return t;
+        }
+        let flipped = Self::anchor_translation(
+            self.side.opposite(),
+            self.gap,
+            cross,
+            pos,
+            anchor_size,
+            ov_size,
+        ) + self.offset;
+        let candidate = if overflows(flipped, ov_size) {
+            t
+        } else {
+            flipped
+        };
+        let max_x = (vp.width - ov_size.width).max(0.0);
+        let max_y = (vp.height - ov_size.height).max(0.0);
+        Vec2::new(
+            candidate.x.max(0.0).min(max_x),
+            candidate.y.max(0.0).min(max_y),
+        )
+    }
 }
 
 impl ElementChildren for Overlay {
@@ -546,19 +684,9 @@ impl ElementBuild for Overlay {
 
         let mut result = content_size;
 
-        let clip = self.clip;
-        let side = self.side;
-        let gap = self.gap;
-        let offset = self.offset;
-        let h_align = self.h_align;
-        let v_align = self.v_align;
-        let cross = match side {
-            Side::Top | Side::Bottom => h_align,
-            Side::Left | Side::Right => v_align,
-        };
         let anchor_data = self
             .anchor
-            .and_then(|a| compute_anchor_pos(a, *id, nodes));
+            .and_then(|a| self.compute_anchor_pos(a, *id, nodes));
         let has_anchor = anchor_data.is_some();
         let viewport = if self.flip && has_anchor {
             nodes.get_resource::<Viewport>().copied()
@@ -569,25 +697,42 @@ impl ElementBuild for Overlay {
         for ov in &self.overlays {
             let ov_size = nodes.get_size(ov);
             let t = if let Some((pos, size)) = anchor_data {
-                resolve_anchor_offset(
-                    side, cross, gap, offset, pos, size, ov_size,
-                    viewport,
+                self.resolve_anchor_offset(
+                    pos, size, ov_size, viewport,
                 )
             } else {
-                let p = alignment_offset(
-                    h_align,
-                    v_align,
-                    content_size,
-                    ov_size,
-                ) + offset;
-                if clip {
-                    clamp_to_bounds(p, ov_size, content_size)
-                } else {
-                    p
+                let x = match self.h_align {
+                    Align::Start => 0.0,
+                    Align::Center => {
+                        (content_size.width - ov_size.width) / 2.0
+                    }
+                    Align::End => content_size.width - ov_size.width,
+                };
+                let y = match self.v_align {
+                    Align::Start => 0.0,
+                    Align::Center => {
+                        (content_size.height - ov_size.height) / 2.0
+                    }
+                    Align::End => {
+                        content_size.height - ov_size.height
+                    }
+                };
+                let mut p = Vec2::new(x, y) + self.offset;
+                if self.clip {
+                    let max_x =
+                        (content_size.width - ov_size.width).max(0.0);
+                    let max_y = (content_size.height
+                        - ov_size.height)
+                        .max(0.0);
+                    p = Vec2::new(
+                        p.x.max(0.0).min(max_x),
+                        p.y.max(0.0).min(max_y),
+                    );
                 }
+                p
             };
             nodes.set_translation(ov, t);
-            if !has_anchor && !clip {
+            if !has_anchor && !self.clip {
                 result.width = result.width.max(t.x + ov_size.width);
                 result.height =
                     result.height.max(t.y + ov_size.height);
@@ -595,287 +740,6 @@ impl ElementBuild for Overlay {
         }
 
         constraint.constrain(result)
-    }
-}
-
-fn alignment_offset(
-    h_align: Align,
-    v_align: Align,
-    content: Size,
-    child: Size,
-) -> Vec2 {
-    let x = match h_align {
-        Align::Start => 0.0,
-        Align::Center => (content.width - child.width) / 2.0,
-        Align::End => content.width - child.width,
-    };
-    let y = match v_align {
-        Align::Start => 0.0,
-        Align::Center => (content.height - child.height) / 2.0,
-        Align::End => content.height - child.height,
-    };
-    Vec2::new(x, y)
-}
-
-fn clamp_to_bounds(
-    pos: Vec2,
-    child_size: Size,
-    bounds: Size,
-) -> Vec2 {
-    let max_x = (bounds.width - child_size.width).max(0.0);
-    let max_y = (bounds.height - child_size.height).max(0.0);
-    Vec2::new(pos.x.max(0.0).min(max_x), pos.y.max(0.0).min(max_y))
-}
-
-fn resolve_anchor_offset(
-    side: Side,
-    cross: Align,
-    gap: f32,
-    offset: Vec2,
-    pos: Vec2,
-    anchor_size: Size,
-    ov_size: Size,
-    viewport: Option<Viewport>,
-) -> Vec2 {
-    let t = anchor_translation(
-        side,
-        cross,
-        gap,
-        pos,
-        anchor_size,
-        ov_size,
-    ) + offset;
-    let Some(vp) = viewport else {
-        return t;
-    };
-    if !anchor_overflows(t, ov_size, &vp) {
-        return t;
-    }
-    let flipped = anchor_translation(
-        side.opposite(),
-        cross,
-        gap,
-        pos,
-        anchor_size,
-        ov_size,
-    ) + offset;
-    let candidate = if anchor_overflows(flipped, ov_size, &vp) {
-        t
-    } else {
-        flipped
-    };
-    clamp_to_bounds(
-        candidate,
-        ov_size,
-        Size::new(vp.width, vp.height),
-    )
-}
-
-fn compute_anchor_pos(
-    anchor_id: ElementId,
-    overlay_id: ElementId,
-    nodes: &ElementNodes,
-) -> Option<(Vec2, Size)> {
-    let anchor_node = nodes.get_node(&anchor_id)?;
-    let size = anchor_node.size;
-    let mut pos = anchor_node.translation;
-    let mut current = anchor_node.parent_id?;
-    loop {
-        if current == overlay_id {
-            return Some((pos, size));
-        }
-        let node = nodes.get_node(&current)?;
-        pos = pos + node.translation;
-        current = node.parent_id?;
-    }
-}
-
-fn anchor_translation(
-    side: Side,
-    cross: Align,
-    gap: f32,
-    anchor_pos: Vec2,
-    anchor_size: Size,
-    child_size: Size,
-) -> Vec2 {
-    let (main, cross_val) = match side {
-        Side::Top => (
-            anchor_pos.y - child_size.height - gap,
-            cross_align(
-                cross,
-                anchor_pos.x,
-                anchor_size.width,
-                child_size.width,
-            ),
-        ),
-        Side::Bottom => (
-            anchor_pos.y + anchor_size.height + gap,
-            cross_align(
-                cross,
-                anchor_pos.x,
-                anchor_size.width,
-                child_size.width,
-            ),
-        ),
-        Side::Left => (
-            cross_align(
-                cross,
-                anchor_pos.y,
-                anchor_size.height,
-                child_size.height,
-            ),
-            anchor_pos.x - child_size.width - gap,
-        ),
-        Side::Right => (
-            cross_align(
-                cross,
-                anchor_pos.y,
-                anchor_size.height,
-                child_size.height,
-            ),
-            anchor_pos.x + anchor_size.width + gap,
-        ),
-    };
-    match side {
-        Side::Top | Side::Bottom => Vec2::new(cross_val, main),
-        Side::Left | Side::Right => Vec2::new(main, cross_val),
-    }
-}
-
-fn cross_align(
-    align: Align,
-    anchor_start: f32,
-    anchor_span: f32,
-    child_span: f32,
-) -> f32 {
-    match align {
-        Align::Start => anchor_start,
-        Align::Center => {
-            anchor_start + (anchor_span - child_span) / 2.0
-        }
-        Align::End => anchor_start + anchor_span - child_span,
-    }
-}
-
-fn anchor_overflows(
-    pos: Vec2,
-    size: Size,
-    viewport: &Viewport,
-) -> bool {
-    pos.x < 0.0
-        || pos.y < 0.0
-        || pos.x + size.width > viewport.width
-        || pos.y + size.height > viewport.height
-}
-
-pub struct OverlayComposer {
-    content: Option<ElementId>,
-    overlays: Vec<ElementId>,
-    anchor: Option<ElementId>,
-    side: Option<Side>,
-    gap: Option<f32>,
-    h_align: Option<Align>,
-    v_align: Option<Align>,
-    offset: Option<Vec2>,
-    clip: Option<bool>,
-    flip: Option<bool>,
-}
-
-impl OverlayComposer {
-    pub fn new() -> Self {
-        Self {
-            content: None,
-            overlays: Vec::new(),
-            anchor: None,
-            side: None,
-            gap: None,
-            h_align: None,
-            v_align: None,
-            offset: None,
-            clip: None,
-            flip: None,
-        }
-    }
-
-    pub fn content(mut self, id: impl Into<ElementId>) -> Self {
-        self.content = Some(id.into());
-        self
-    }
-
-    pub fn overlay(mut self, id: impl Into<ElementId>) -> Self {
-        self.overlays.push(id.into());
-        self
-    }
-
-    pub fn anchor(mut self, id: impl Into<ElementId>) -> Self {
-        self.anchor = Some(id.into());
-        self
-    }
-
-    pub fn side(mut self, s: Side) -> Self {
-        self.side = Some(s);
-        self
-    }
-
-    pub fn gap(mut self, g: f32) -> Self {
-        self.gap = Some(g);
-        self
-    }
-
-    pub fn h_align(mut self, a: Align) -> Self {
-        self.h_align = Some(a);
-        self
-    }
-
-    pub fn v_align(mut self, a: Align) -> Self {
-        self.v_align = Some(a);
-        self
-    }
-
-    pub fn offset(mut self, v: Vec2) -> Self {
-        self.offset = Some(v);
-        self
-    }
-
-    pub fn clip(mut self, b: bool) -> Self {
-        self.clip = Some(b);
-        self
-    }
-
-    pub fn flip(mut self, b: bool) -> Self {
-        self.flip = Some(b);
-        self
-    }
-}
-
-impl Default for OverlayComposer {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<W> Composer<W> for OverlayComposer {
-    type Style = Overlay;
-    type Element = Overlay;
-
-    fn compose(
-        self,
-        style: Self::Style,
-        ctx: &mut FynixCtx<'_, '_, W>,
-    ) -> ElementHandle<Overlay> {
-        ctx.add_with::<Overlay>(move |o, _| {
-            o.content = self.content;
-            o.overlays = self.overlays;
-            o.h_align = self.h_align.unwrap_or(style.h_align);
-            o.v_align = self.v_align.unwrap_or(style.v_align);
-            o.offset = self.offset.unwrap_or(style.offset);
-            o.clip = self.clip.unwrap_or(style.clip);
-            o.anchor = self.anchor.or(style.anchor);
-            o.side = self.side.unwrap_or(style.side);
-            o.gap = self.gap.unwrap_or(style.gap);
-            o.flip = self.flip.unwrap_or(style.flip);
-        })
-        .handle()
     }
 }
 

--- a/crates/fynix_elements/src/lib.rs
+++ b/crates/fynix_elements/src/lib.rs
@@ -711,26 +711,18 @@ impl ElementBuild for Overlay {
                     viewport,
                 )
             } else {
-                let align_x = match self.h_align {
-                    Align::Start => 0.0,
-                    Align::Center => {
-                        (content_size.width - overlay_size.width)
-                            / 2.0
-                    }
-                    Align::End => {
-                        content_size.width - overlay_size.width
-                    }
-                };
-                let align_y = match self.v_align {
-                    Align::Start => 0.0,
-                    Align::Center => {
-                        (content_size.height - overlay_size.height)
-                            / 2.0
-                    }
-                    Align::End => {
-                        content_size.height - overlay_size.height
-                    }
-                };
+                let align_x = Self::cross_align(
+                    self.h_align,
+                    0.0,
+                    content_size.width,
+                    overlay_size.width,
+                );
+                let align_y = Self::cross_align(
+                    self.v_align,
+                    0.0,
+                    content_size.height,
+                    overlay_size.height,
+                );
                 let mut pos =
                     Vec2::new(align_x, align_y) + self.offset;
                 if self.clip {

--- a/examples/vello_winit_examples/examples/hello_world.rs
+++ b/examples/vello_winit_examples/examples/hello_world.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use fynix::interaction::Handler;
+use fynix::interaction::{Handler, HandlerFn};
 use fynix::prelude::*;
 use fynix_elements::parley::fontique::{Blob, GenericFamily};
 use fynix_elements::{
@@ -309,36 +309,36 @@ impl ActionButton {
     /// Sets the primary (left) click handler.
     fn on_click(
         mut self,
-        handler: fn(PrimaryClick<Mouse>, &mut Response<HelloWorld>),
+        handler: impl HandlerFn<PrimaryClick<Mouse>, HelloWorld>,
     ) -> Self {
-        self.on_click = Some(Handler::Ptr(handler));
+        self.on_click = Some(handler.into());
         self
     }
 
     /// Sets the secondary (right) click handler.
     fn on_right_click(
         mut self,
-        handler: fn(SecondaryClick<Mouse>, &mut Response<HelloWorld>),
+        handler: impl HandlerFn<SecondaryClick<Mouse>, HelloWorld>,
     ) -> Self {
-        self.on_right_click = Some(Handler::Ptr(handler));
+        self.on_right_click = Some(Handler::new(handler));
         self
     }
 
     /// Sets the pointer-enter handler, run after the cursor change.
     fn on_enter(
         mut self,
-        handler: fn(PointerEnter<Mouse>, &mut Response<HelloWorld>),
+        handler: impl HandlerFn<PointerEnter<Mouse>, HelloWorld>,
     ) -> Self {
-        self.on_enter = Some(Handler::Ptr(handler));
+        self.on_enter = Some(Handler::new(handler));
         self
     }
 
     /// Sets the pointer-leave handler, run after the cursor change.
     fn on_leave(
         mut self,
-        handler: fn(PointerLeave<Mouse>, &mut Response<HelloWorld>),
+        handler: impl HandlerFn<PointerLeave<Mouse>, HelloWorld>,
     ) -> Self {
-        self.on_leave = Some(Handler::Ptr(handler));
+        self.on_leave = Some(Handler::new(handler));
         self
     }
 }
@@ -377,20 +377,20 @@ impl Composer<HelloWorld> for ActionButton {
                 }));
             })
             // Enter/leave set the cursor, then run any user handler.
-            .interact_with::<PointerEnter<Mouse>>(move |i, res| {
+            .interact::<PointerEnter<Mouse>>(move |i, res| {
                 res.cursor_icon = CursorIcon::Pointer;
                 if let Some(on_enter) = &on_enter {
                     on_enter.call(i, res);
                 }
             })
-            .interact_with::<PointerLeave<Mouse>>(move |i, res| {
+            .interact::<PointerLeave<Mouse>>(move |i, res| {
                 res.cursor_icon = CursorIcon::Default;
                 if let Some(on_leave) = &on_leave {
                     on_leave.call(i, res);
                 }
             });
 
-        // Forward the click handlers as built `Handler`s.
+        // Forward the built click handlers directly.
         if let Some(on_click) = on_click {
             button = button.interact_raw(on_click);
         }

--- a/examples/vello_winit_examples/examples/hello_world.rs
+++ b/examples/vello_winit_examples/examples/hello_world.rs
@@ -56,7 +56,7 @@ fn main_layout(ctx: &mut FynixCtx<HelloWorld>) -> ElementId {
             // Header.
             let title = ctx
                 .add_with::<Label>(|l, _| {
-                    l.text = "Fynix Interactions".into();
+                    l.text = "Counter".into();
                     l.font_size = 34.0;
                 })
                 .id();
@@ -217,7 +217,7 @@ struct HelloWorld {
 
 impl DemoWorld for HelloWorld {
     fn window_title(&self) -> &'static str {
-        "Fynix Interactions"
+        "Hello World"
     }
 
     fn update(&mut self, dt: Duration) {

--- a/examples/vello_winit_examples/examples/toolbar/builders.rs
+++ b/examples/vello_winit_examples/examples/toolbar/builders.rs
@@ -5,8 +5,8 @@ use fynix::interaction::{Handler, HandlerFn};
 use fynix::prelude::*;
 use fynix::reactive::ChangedFn;
 use fynix_elements::{
-    Align, Button, Frame, Horizontal, Label, OverlayComposer, Pad,
-    Side, Vertical,
+    Align, Button, Frame, Horizontal, Label, Overlay, Pad, Side,
+    Vertical,
 };
 use fynix_interaction::prelude::*;
 use vello::peniko::{Brush, Color};
@@ -453,15 +453,14 @@ fn build_toolbar(ctx: &mut FynixCtx<CadWorld>) -> ElementId {
             DropdownId::Draw => draw_arrow,
             DropdownId::Modify => modify_arrow,
         };
-        ctx.compose(
-            OverlayComposer::new()
-                .content(frame_id)
-                .overlay(dropdown)
-                .anchor(arrow_id)
-                .side(Side::Bottom)
-                .h_align(Align::Start)
-                .gap(GAP_V),
-        )
+        ctx.add_with::<Overlay>(|o, _| {
+            o.content = Some(frame_id);
+            o.overlays.push(dropdown);
+            o.anchor = Some(arrow_id);
+            o.side = Side::Bottom;
+            o.h_align = Align::Start;
+            o.gap = GAP_V;
+        })
         .id()
     } else {
         frame_id

--- a/examples/vello_winit_examples/examples/toolbar/builders.rs
+++ b/examples/vello_winit_examples/examples/toolbar/builders.rs
@@ -225,9 +225,10 @@ fn undo_redo_buttons(ctx: &mut FynixCtx<CadWorld>) -> ElementId {
             |w| !w.undo_stack.is_empty(),
             |w| w.undo_hovered,
             move |w| {
-                let current = (w.undo_hovered, w.undo_stack.len());
-                let changed = cell_diff(&prev_undo, current);
-                changed
+                cell_diff(
+                    &prev_undo,
+                    (w.undo_hovered, w.undo_stack.len()),
+                )
             },
             |w, v| w.undo_hovered = v,
             move |_, res| {
@@ -244,9 +245,10 @@ fn undo_redo_buttons(ctx: &mut FynixCtx<CadWorld>) -> ElementId {
             |w| !w.redo_stack.is_empty(),
             |w| w.redo_hovered,
             move |w| {
-                let current = (w.redo_hovered, w.redo_stack.len());
-                let changed = cell_diff(&prev_redo, current);
-                changed
+                cell_diff(
+                    &prev_redo,
+                    (w.redo_hovered, w.redo_stack.len()),
+                )
             },
             |w, v| w.redo_hovered = v,
             move |_, res| {

--- a/examples/vello_winit_examples/examples/toolbar/builders.rs
+++ b/examples/vello_winit_examples/examples/toolbar/builders.rs
@@ -1,0 +1,565 @@
+use core::cell::Cell;
+use std::rc::Rc;
+
+use fynix::interaction::{Handler, HandlerFn};
+use fynix::prelude::*;
+use fynix::reactive::ChangedFn;
+use fynix_elements::{
+    Align, Button, Frame, Horizontal, Label, OverlayComposer, Pad,
+    Side, Vertical,
+};
+use fynix_interaction::prelude::*;
+use vello::peniko::{Brush, Color};
+use winit::window::CursorIcon;
+
+use crate::CadWorld;
+use crate::elements::{
+    IconLabelButton, ToolButton, ToolIcon, ToolbarRow,
+};
+use crate::helpers::*;
+use crate::theme::*;
+
+fn arrow_button(
+    ctx: &mut FynixCtx<CadWorld>,
+    id: DropdownId,
+    is_expanded: bool,
+) -> ElementId {
+    ctx.compose(ToolButton::new("▾", is_expanded).on_click(
+        move |_, res| {
+            res.push_undo_state();
+            res.expanded_dropdown = match res.expanded_dropdown {
+                Some(x) if x == id => None,
+                _ => Some(id),
+            };
+        },
+    ))
+    .id()
+}
+
+fn split_button(
+    ctx: &mut FynixCtx<CadWorld>,
+    id: DropdownId,
+    default_tool: Tool,
+    is_expanded: bool,
+    group_has_active: bool,
+) -> (ElementId, ElementId) {
+    let arrow_id = arrow_button(ctx, id, is_expanded);
+    let split_id = ctx
+        .add_with::<Horizontal>(|h, ctx| {
+            h.add(
+                ctx.compose(
+                    ToolButton::for_tool(
+                        default_tool,
+                        group_has_active,
+                    )
+                    .on_click(move |_, res| {
+                        res.select_tool(default_tool);
+                    }),
+                ),
+            );
+            h.add(arrow_id);
+        })
+        .id();
+    (split_id, arrow_id)
+}
+
+fn dropdown_panel(
+    ctx: &mut FynixCtx<CadWorld>,
+    tools: &[Tool],
+    active: Tool,
+) -> ElementId {
+    let content_id = ctx
+        .add_with::<Vertical>(|col, ctx| {
+            for (i, tool) in tools.iter().enumerate() {
+                if i > 0 {
+                    col.add(ctx.add_with::<Pad>(|p, _| {
+                        *p = Pad::vertical(4.0);
+                    }));
+                }
+                let tool_val = *tool;
+                col.add(
+                    ctx.compose(
+                        ToolButton::for_tool(
+                            tool_val,
+                            tool_val == active,
+                        )
+                        .on_click(
+                            move |_, res| {
+                                res.select_tool(tool_val);
+                            },
+                        ),
+                    ),
+                );
+            }
+        })
+        .id();
+    panel_frame(ctx, content_id)
+}
+
+fn toggle_flag(
+    ctx: &mut FynixCtx<CadWorld>,
+    label: &str,
+    get: fn(&CadWorld) -> bool,
+    toggle: fn(&mut CadWorld),
+) -> ElementId {
+    let initial = get(ctx.world);
+    let prev = Cell::new(initial);
+    let prev_hovered = Cell::new(false);
+    let hovered = Rc::new(Cell::new(false));
+    let fg = unified_fg(true);
+
+    ctx.add_with::<Button>(|b, ctx| {
+        b.fill = unified_fill(initial, false, true);
+        b.set_child(ctx.add_with::<Pad>(|p, ctx| {
+            *p = Pad::symmetric(2.0, 6.0);
+            p.set_child(ctx.add_with::<Label>(|l, _| {
+                l.text = label.into();
+                l.fill = fg;
+            }));
+        }));
+    })
+    .bind(
+        {
+            let hovered = Rc::clone(&hovered);
+            move |w| {
+                let on = get(w);
+                let h = hovered.get();
+                let on_changed = cell_diff(&prev, on);
+                let hover_changed = cell_diff(&prev_hovered, h);
+                on_changed || hover_changed
+            }
+        },
+        {
+            let hovered = Rc::clone(&hovered);
+            move |w| {
+                let on = get(w);
+                unified_fill(on, hovered.get(), true)
+            }
+        },
+        |b: &mut Button| &mut b.fill,
+    )
+    .interact_raw(Handler::<PointerEnter<Mouse>, _>::new({
+        let hovered = Rc::clone(&hovered);
+        move |_, res: &mut Response<'_, CadWorld>| {
+            hovered.set(true);
+            res.cursor_icon = CursorIcon::Pointer;
+        }
+    }))
+    .interact_raw(Handler::<PointerLeave<Mouse>, _>::new({
+        let hovered = Rc::clone(&hovered);
+        move |_, res: &mut Response<'_, CadWorld>| {
+            hovered.set(false);
+            res.cursor_icon = CursorIcon::Default;
+        }
+    }))
+    .interact_raw(Handler::new(
+        move |_: PrimaryClick<Mouse>,
+              res: &mut Response<'_, CadWorld>| {
+            toggle(res);
+        },
+    ))
+    .id()
+}
+
+fn shortcut_button<GetE, GetH>(
+    ctx: &mut FynixCtx<CadWorld>,
+    icon: &str,
+    label: &str,
+    get_enabled: GetE,
+    get_hovered: GetH,
+    get_changed: impl ChangedFn<CadWorld>,
+    set_hovered: impl Fn(&mut CadWorld, bool) + 'static + Copy,
+    on_click: impl HandlerFn<PrimaryClick<Mouse>, CadWorld>,
+) -> ElementId
+where
+    GetE: Fn(&CadWorld) -> bool + 'static + Copy,
+    GetH: Fn(&CadWorld) -> bool + 'static + Copy,
+{
+    let enabled = get_enabled(ctx.world);
+    let hovered = get_hovered(ctx.world);
+
+    ctx.compose(IconLabelButton {
+        label: label.into(),
+        icon_text: Some(icon.into()),
+        tool_icon: None,
+        accent: false,
+        fill: unified_fill(false, hovered, enabled),
+        fg: unified_fg(enabled),
+        enabled,
+        on_click: Some(Handler::new(on_click)),
+        on_enter: Some(Handler::new(move |_, res| {
+            set_hovered(res, true);
+            res.cursor_icon = CursorIcon::Pointer;
+        })),
+        on_leave: Some(Handler::new(move |_, res| {
+            set_hovered(res, false);
+            res.cursor_icon = CursorIcon::Default;
+        })),
+    })
+    .bind(
+        get_changed,
+        move |w| {
+            let e = get_enabled(w);
+            let h = get_hovered(w);
+            unified_fill(false, h, e)
+        },
+        |b: &mut Button| &mut b.fill,
+    )
+    .id()
+}
+
+fn undo_redo_buttons(ctx: &mut FynixCtx<CadWorld>) -> ElementId {
+    let prev_undo = Cell::new((
+        ctx.world.undo_hovered,
+        ctx.world.undo_stack.len(),
+    ));
+    let prev_redo = Cell::new((
+        ctx.world.redo_hovered,
+        ctx.world.redo_stack.len(),
+    ));
+    ctx.add_with::<Horizontal>(|h, ctx| {
+        h.add(shortcut_button(
+            ctx,
+            "\u{21A9}",
+            "Undo",
+            |w| !w.undo_stack.is_empty(),
+            |w| w.undo_hovered,
+            move |w| {
+                let current = (w.undo_hovered, w.undo_stack.len());
+                let changed = cell_diff(&prev_undo, current);
+                changed
+            },
+            |w, v| w.undo_hovered = v,
+            move |_, res| {
+                res.undo();
+            },
+        ));
+        h.add(ctx.add_with::<Pad>(|sp, _| {
+            *sp = Pad::horizontal(GAP / 2.0);
+        }));
+        h.add(shortcut_button(
+            ctx,
+            "\u{21AA}",
+            "Redo",
+            |w| !w.redo_stack.is_empty(),
+            |w| w.redo_hovered,
+            move |w| {
+                let current = (w.redo_hovered, w.redo_stack.len());
+                let changed = cell_diff(&prev_redo, current);
+                changed
+            },
+            |w, v| w.redo_hovered = v,
+            move |_, res| {
+                res.redo();
+            },
+        ));
+    })
+    .id()
+}
+
+fn build_menu_bar(ctx: &mut FynixCtx<CadWorld>) -> ElementId {
+    ctx.add_with::<Horizontal>(|h, ctx| {
+        apply_menu_bar(ctx);
+
+        let mut first = true;
+        for item in [
+            "File", "Edit", "View", "Insert", "Format", "Tools",
+            "Draw", "Modify",
+        ] {
+            if !first {
+                h.add(vertical_separator(ctx));
+            }
+            first = false;
+
+            h.add(
+                ctx.add_with::<Button>(|b, ctx| {
+                    let label_text = item.to_string();
+                    let label_id = ctx
+                        .add_with::<Label>(|l, _| {
+                            l.text = label_text;
+                        })
+                        .id();
+                    b.set_child(
+                        ctx.add_with::<Pad>(|p, _| {
+                            *p = Pad::symmetric(2.0, 6.0);
+                            p.set_child(label_id);
+                        })
+                        .id(),
+                    );
+                })
+                .id(),
+            );
+        }
+    })
+    .id()
+}
+
+fn status_bar_icon_row(
+    ctx: &mut FynixCtx<CadWorld>,
+    active: Tool,
+) -> ElementId {
+    ctx.add_with::<Horizontal>(|h, ctx| {
+        h.add(ctx.add_with::<ToolIcon>(|icon, _| {
+            icon.tool = Some(active);
+            icon.color = Brush::Solid(ACCENT);
+            icon.size = 14.0;
+        }));
+        h.add(ctx.add_with::<Pad>(|sp, _| {
+            *sp = Pad::horizontal(4.0);
+        }));
+        h.add(ctx.add_with::<Label>(|l, _| {
+            l.text = active.display_label().into();
+            l.fill = Brush::Solid(MUTED_TEXT);
+        }));
+        h.add(tight_spacer(ctx));
+        apply_toolbar_toggle(ctx);
+        h.add(toggle_flag(
+            ctx,
+            "Snap",
+            |w| w.snap_enabled,
+            |w| w.snap_enabled = !w.snap_enabled,
+        ));
+        h.add(tight_spacer(ctx));
+        h.add(toggle_flag(
+            ctx,
+            "Grid",
+            |w| w.grid_enabled,
+            |w| w.grid_enabled = !w.grid_enabled,
+        ));
+        h.add(tight_spacer(ctx));
+        h.add(toggle_flag(
+            ctx,
+            "Ortho",
+            |w| w.ortho_enabled,
+            |w| w.ortho_enabled = !w.ortho_enabled,
+        ));
+    })
+    .id()
+}
+
+fn status_bar_hint_row(
+    ctx: &mut FynixCtx<CadWorld>,
+    active: Tool,
+) -> ElementId {
+    header_label(ctx, active.hint())
+}
+
+fn build_status_bar(
+    ctx: &mut FynixCtx<CadWorld>,
+    active: Tool,
+) -> ElementId {
+    ctx.add_with::<Vertical>(|v, ctx| {
+        v.add(add_separator(ctx));
+        v.add(ctx.add_with::<Pad>(|p, ctx| {
+            *p = Pad::new(6.0, 12.0, 6.0, 12.0);
+            p.set_child(ctx.add_with::<Vertical>(|v, ctx| {
+                v.add(status_bar_icon_row(ctx, active));
+                v.add(ctx.add_with::<Pad>(|sp, _| {
+                    *sp = Pad::vertical(1.0);
+                }));
+                v.add(status_bar_hint_row(ctx, active));
+            }));
+        }));
+    })
+    .id()
+}
+
+fn build_toolbar_content(
+    ctx: &mut FynixCtx<CadWorld>,
+    active: Tool,
+    draw_split: ElementId,
+    modify_split: ElementId,
+) -> ElementId {
+    let row_id = ctx
+        .add_with::<Horizontal>(|row, ctx| {
+            let select_id = ctx
+                .compose(
+                    ToolButton::for_tool(
+                        Tool::Select,
+                        active == Tool::Select,
+                    )
+                    .on_click(|_, res| {
+                        res.select_tool(Tool::Select);
+                    }),
+                )
+                .id();
+            row.add(toolbar_group(ctx, "SELECT", select_id));
+
+            row.add(vertical_separator(ctx));
+
+            row.add(toolbar_group(ctx, "DRAW", draw_split));
+
+            row.add(vertical_separator(ctx));
+
+            row.add(toolbar_group(ctx, "MODIFY", modify_split));
+
+            row.add(vertical_separator(ctx));
+
+            let undo_id = undo_redo_buttons(ctx);
+            row.add(toolbar_group(ctx, "UNDO", undo_id));
+        })
+        .id();
+
+    panel_frame(ctx, row_id)
+}
+
+fn toolbar_group(
+    ctx: &mut FynixCtx<'_, '_, CadWorld>,
+    header: &str,
+    content: ElementId,
+) -> ElementId {
+    ctx.add_with::<Vertical>(|v, ctx| {
+        let header_id = header_label(ctx, header);
+
+        let separator_id = ctx
+            .add_with::<Frame>(|f, _| {
+                f.fill = Brush::Solid(SEPARATOR);
+                f.corner_radius = 0.0;
+                f.top = 2.0;
+                f.bottom = 1.0;
+                f.left = PAD_H;
+                f.right = PAD_H;
+            })
+            .id();
+
+        let spacer_id = ctx
+            .add_with::<Pad>(|p, _| {
+                *p = Pad::vertical(4.0);
+            })
+            .id();
+
+        v.add(header_id)
+            .add(separator_id)
+            .add(spacer_id)
+            .add(content);
+    })
+    .id()
+}
+
+fn build_toolbar(ctx: &mut FynixCtx<CadWorld>) -> ElementId {
+    let active = ctx.world.active_tool;
+    let expanded = ctx.world.expanded_dropdown;
+
+    let (draw_split, draw_arrow) = split_button(
+        ctx,
+        DropdownId::Draw,
+        Tool::Line,
+        expanded == Some(DropdownId::Draw),
+        DRAW_TOOLS.contains(&active),
+    );
+    let (modify_split, modify_arrow) = split_button(
+        ctx,
+        DropdownId::Modify,
+        Tool::Move,
+        expanded == Some(DropdownId::Modify),
+        MODIFY_TOOLS.contains(&active),
+    );
+
+    let frame_id =
+        build_toolbar_content(ctx, active, draw_split, modify_split);
+
+    if let Some(id) = expanded {
+        let tools = match id {
+            DropdownId::Draw => DRAW_TOOLS,
+            DropdownId::Modify => MODIFY_TOOLS,
+        };
+        let dropdown = dropdown_panel(ctx, tools, active);
+        let arrow_id = match id {
+            DropdownId::Draw => draw_arrow,
+            DropdownId::Modify => modify_arrow,
+        };
+        ctx.compose(
+            OverlayComposer::new()
+                .content(frame_id)
+                .overlay(dropdown)
+                .anchor(arrow_id)
+                .side(Side::Bottom)
+                .h_align(Align::Start)
+                .gap(GAP_V),
+        )
+        .id()
+    } else {
+        frame_id
+    }
+}
+
+fn build_hint_bar(ctx: &mut FynixCtx<CadWorld>) -> ElementId {
+    let hint_changed = hint_changed(ctx.world);
+    let initial_hint: String =
+        ctx.world.hovered_hint.unwrap_or("").into();
+    let hint_label = ctx
+        .add_with::<Label>(|l, _| {
+            l.text = initial_hint;
+            l.font_size = HEADER_FONT;
+            l.fill = Brush::Solid(Color::WHITE);
+        })
+        .bind(
+            hint_changed,
+            |w| w.hovered_hint.unwrap_or("").into(),
+            |l: &mut Label| &mut l.text,
+        )
+        .id();
+
+    let hint_content = ctx
+        .add_with::<Pad>(|p, _| {
+            p.left = OUTER_PAD;
+            p.right = OUTER_PAD;
+            p.top = 4.0;
+            p.bottom = 4.0;
+            p.set_child(hint_label);
+        })
+        .id();
+
+    dismiss_on_click(ctx, hint_content)
+}
+
+pub(crate) fn build_app(ctx: &mut FynixCtx<CadWorld>) -> ElementId {
+    let prev_watcher = Cell::new((
+        ctx.world.active_tool,
+        ctx.world.expanded_dropdown,
+        ctx.world.undo_stack.len(),
+        ctx.world.redo_stack.len(),
+    ));
+    ctx.add_with::<Vertical>(|app, ctx| {
+        app.add(build_menu_bar(ctx));
+        app.add(
+            ctx.watch(
+                move |w| {
+                    let current = (
+                        w.active_tool,
+                        w.expanded_dropdown,
+                        w.undo_stack.len(),
+                        w.redo_stack.len(),
+                    );
+                    cell_diff(&prev_watcher, current)
+                },
+                |ctx| {
+                    let active = ctx.world.active_tool;
+
+                    Some(
+                        ctx.add_with::<Vertical>(|content, ctx| {
+                            apply_base(ctx);
+
+                            content.add(ctx.add_with::<ToolbarRow>(
+                                |row, ctx| {
+                                    row.children
+                                        .push(build_toolbar(ctx));
+                                    row.children.push(
+                                        build_status_bar(ctx, active),
+                                    );
+                                },
+                            ));
+
+                            content.add(add_separator(ctx));
+
+                            content.add(build_hint_bar(ctx));
+                        })
+                        .id(),
+                    )
+                },
+            )
+            .id(),
+        );
+    })
+    .id()
+}

--- a/examples/vello_winit_examples/examples/toolbar/builders.rs
+++ b/examples/vello_winit_examples/examples/toolbar/builders.rs
@@ -161,22 +161,16 @@ fn toggle_flag(
     .id()
 }
 
-fn shortcut_button<GetE, GetH>(
+fn shortcut_button(
     ctx: &mut FynixCtx<CadWorld>,
     icon: &str,
     label: &str,
-    get_enabled: GetE,
-    get_hovered: GetH,
+    get_state: fn(&CadWorld) -> (bool, bool),
     get_changed: impl ChangedFn<CadWorld>,
     set_hovered: impl Fn(&mut CadWorld, bool) + 'static + Copy,
     on_click: impl HandlerFn<PrimaryClick<Mouse>, CadWorld>,
-) -> ElementId
-where
-    GetE: Fn(&CadWorld) -> bool + 'static + Copy,
-    GetH: Fn(&CadWorld) -> bool + 'static + Copy,
-{
-    let enabled = get_enabled(ctx.world);
-    let hovered = get_hovered(ctx.world);
+) -> ElementId {
+    let (enabled, hovered) = get_state(ctx.world);
 
     ctx.compose(IconLabelButton {
         label: label.into(),
@@ -199,8 +193,7 @@ where
     .bind(
         get_changed,
         move |w| {
-            let e = get_enabled(w);
-            let h = get_hovered(w);
+            let (e, h) = get_state(w);
             unified_fill(false, h, e)
         },
         |b: &mut Button| &mut b.fill,
@@ -222,8 +215,7 @@ fn undo_redo_buttons(ctx: &mut FynixCtx<CadWorld>) -> ElementId {
             ctx,
             "\u{21A9}",
             "Undo",
-            |w| !w.undo_stack.is_empty(),
-            |w| w.undo_hovered,
+            |w| (!w.undo_stack.is_empty(), w.undo_hovered),
             move |w| {
                 cell_diff(
                     &prev_undo,
@@ -242,8 +234,7 @@ fn undo_redo_buttons(ctx: &mut FynixCtx<CadWorld>) -> ElementId {
             ctx,
             "\u{21AA}",
             "Redo",
-            |w| !w.redo_stack.is_empty(),
-            |w| w.redo_hovered,
+            |w| (!w.redo_stack.is_empty(), w.redo_hovered),
             move |w| {
                 cell_diff(
                     &prev_redo,

--- a/examples/vello_winit_examples/examples/toolbar/builders.rs
+++ b/examples/vello_winit_examples/examples/toolbar/builders.rs
@@ -398,7 +398,6 @@ fn toolbar_group(
 
         let separator_id = ctx
             .add_with::<Frame>(|f, _| {
-                f.fill = Brush::Solid(SEPARATOR);
                 f.corner_radius = 0.0;
                 f.top = 2.0;
                 f.bottom = 1.0;

--- a/examples/vello_winit_examples/examples/toolbar/builders.rs
+++ b/examples/vello_winit_examples/examples/toolbar/builders.rs
@@ -14,7 +14,7 @@ use winit::window::CursorIcon;
 
 use crate::CadWorld;
 use crate::elements::{
-    IconLabelButton, ToolButton, ToolIcon, ToolbarRow,
+    IconLabelButton, MenuBarItem, ToolButton, ToolIcon, ToolbarRow,
 };
 use crate::helpers::*;
 use crate::theme::*;
@@ -273,24 +273,7 @@ fn build_menu_bar(ctx: &mut FynixCtx<CadWorld>) -> ElementId {
             }
             first = false;
 
-            h.add(
-                ctx.add_with::<Button>(|b, ctx| {
-                    let label_text = item.to_string();
-                    let label_id = ctx
-                        .add_with::<Label>(|l, _| {
-                            l.text = label_text;
-                        })
-                        .id();
-                    b.set_child(
-                        ctx.add_with::<Pad>(|p, _| {
-                            *p = Pad::symmetric(2.0, 6.0);
-                            p.set_child(label_id);
-                        })
-                        .id(),
-                    );
-                })
-                .id(),
-            );
+            h.add(ctx.compose(MenuBarItem::new(item)).id());
         }
     })
     .id()

--- a/examples/vello_winit_examples/examples/toolbar/elements.rs
+++ b/examples/vello_winit_examples/examples/toolbar/elements.rs
@@ -441,3 +441,45 @@ impl Composer<CadWorld> for ToolButton {
         }
     }
 }
+
+#[derive(Init)]
+pub(crate) struct MenuBarItemStyle;
+
+pub(crate) struct MenuBarItem {
+    label: String,
+}
+
+impl MenuBarItem {
+    pub(crate) fn new(label: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+        }
+    }
+}
+
+impl Composer<CadWorld> for MenuBarItem {
+    type Style = MenuBarItemStyle;
+    type Element = Button;
+
+    fn compose(
+        self,
+        _style: MenuBarItemStyle,
+        ctx: &mut FynixCtx<'_, '_, CadWorld>,
+    ) -> ElementHandle<Button> {
+        let label_id = ctx
+            .add_with::<Label>(|l, _| {
+                l.text = self.label;
+            })
+            .id();
+        ctx.add_with::<Button>(|b, ctx| {
+            b.set_child(
+                ctx.add_with::<Pad>(|p, _| {
+                    *p = Pad::symmetric(2.0, 6.0);
+                    p.set_child(label_id);
+                })
+                .id(),
+            );
+        })
+        .handle()
+    }
+}

--- a/examples/vello_winit_examples/examples/toolbar/elements.rs
+++ b/examples/vello_winit_examples/examples/toolbar/elements.rs
@@ -1,0 +1,443 @@
+use fynix::element::layout::ElementNodes;
+use fynix::element::storage::ElementHandle;
+use fynix::element::table::RenderElementTable;
+use fynix::imaging::{FillRef, PaintSink, StrokeRef};
+use fynix::interaction::{Handler, HandlerFn};
+use fynix::prelude::*;
+use fynix_elements::{Button, Frame, Horizontal, Label, Pad};
+use fynix_interaction::prelude::*;
+use vello::peniko::{Brush, Color};
+use winit::window::CursorIcon;
+
+use crate::CadWorld;
+use crate::helpers::{
+    hovered_tool_changed, unified_fg, unified_fill,
+};
+use crate::theme::*;
+
+/// Lays out toolbar at left edge and status bar at right edge of
+/// the full content width.
+#[derive(Init, Element)]
+pub(crate) struct ToolbarRow {
+    #[elem(children)]
+    pub(crate) children: Vec<ElementId>,
+}
+
+impl ElementBuild for ToolbarRow {
+    fn build(
+        &self,
+        _id: &ElementId,
+        constraint: Constraint,
+        nodes: &mut ElementNodes,
+    ) -> Size {
+        debug_assert!(self.children.len() <= 2);
+        let width = constraint.max.width;
+        let tb_size = self
+            .children
+            .first()
+            .map(|id| nodes.get_size(id))
+            .unwrap_or(Size::ZERO);
+        let sb_size = self
+            .children
+            .get(1)
+            .map(|id| nodes.get_size(id))
+            .unwrap_or(Size::ZERO);
+        if let Some(id) = self.children.first() {
+            nodes.set_translation(id, Vec2::new(0.0, 0.0));
+        }
+        if let Some(id) = self.children.get(1) {
+            nodes.set_translation(
+                id,
+                Vec2::new(width - sb_size.width, 0.0),
+            );
+        }
+        let height = tb_size.height.max(sb_size.height);
+        constraint.constrain(Size::new(width, height))
+    }
+}
+
+#[derive(Init)]
+pub(crate) struct IconLabelButtonStyle {
+    #[init(ACCENT)]
+    accent_color: Color,
+    #[init(CORNER_RADIUS)]
+    corner_radius: f64,
+    #[init(FONT_SIZE)]
+    font_size: f32,
+    #[init(PAD_V)]
+    pad_v: f32,
+    #[init(PAD_H)]
+    pad_h: f32,
+}
+
+pub(crate) struct IconLabelButton {
+    pub label: String,
+    pub icon_text: Option<String>,
+    pub tool_icon: Option<Tool>,
+    pub accent: bool,
+    pub fill: Brush,
+    pub fg: Brush,
+    pub enabled: bool,
+    pub on_click: Option<Handler<PrimaryClick<Mouse>, CadWorld>>,
+    pub on_enter: Option<Handler<PointerEnter<Mouse>, CadWorld>>,
+    pub on_leave: Option<Handler<PointerLeave<Mouse>, CadWorld>>,
+}
+
+impl IconLabelButton {
+    fn build_content(
+        ctx: &mut FynixCtx<'_, '_, CadWorld>,
+        style: &IconLabelButtonStyle,
+        accent: bool,
+        tool_icon: Option<Tool>,
+        icon_text: &Option<String>,
+        label: String,
+        fg: Brush,
+    ) -> ElementId {
+        ctx.add_with::<Horizontal>(|h, ctx| {
+            if accent {
+                h.add(ctx.add_with::<Frame>(|bar, _| {
+                    bar.fill = Brush::Solid(style.accent_color);
+                    bar.corner_radius = 1.5;
+                    bar.top = 2.0;
+                    bar.bottom = 2.0;
+                    bar.left = 1.0;
+                    bar.right = 2.0;
+                }));
+                h.add(ctx.add_with::<Pad>(|sp, _| {
+                    *sp = Pad::horizontal(1.0);
+                }));
+            }
+
+            if let Some(tool) = tool_icon {
+                h.add(ctx.add_with::<Pad>(|dot, _| {
+                    *dot = Pad::horizontal(2.0);
+                }));
+                h.add(ctx.add_with::<ToolIcon>(|icon, _| {
+                    icon.tool = Some(tool);
+                    icon.color = fg.clone();
+                    icon.size = style.font_size as f64 + 2.0;
+                }));
+                h.add(ctx.add_with::<Pad>(|sep, _| {
+                    *sep = Pad::horizontal(4.0);
+                }));
+            } else if let Some(text) = icon_text {
+                h.add(ctx.add_with::<Label>(|l, _| {
+                    l.text = text.clone();
+                    l.font_size = style.font_size;
+                    l.fill = fg.clone();
+                }));
+                h.add(ctx.add_with::<Pad>(|sp, _| {
+                    *sp = Pad::horizontal(3.0);
+                }));
+            }
+
+            h.add(ctx.add_with::<Label>(|l, _| {
+                l.text = label;
+                l.font_size = style.font_size;
+                l.fill = fg;
+            }));
+        })
+        .id()
+    }
+}
+
+impl Composer<CadWorld> for IconLabelButton {
+    type Style = IconLabelButtonStyle;
+    type Element = Button;
+
+    fn compose(
+        self,
+        style: Self::Style,
+        ctx: &mut FynixCtx<'_, '_, CadWorld>,
+    ) -> ElementHandle<Button> {
+        let IconLabelButton {
+            label,
+            icon_text,
+            tool_icon,
+            accent,
+            fill,
+            fg,
+            enabled,
+            on_click,
+            on_enter,
+            on_leave,
+        } = self;
+
+        let content_id = Self::build_content(
+            ctx, &style, accent, tool_icon, &icon_text, label, fg,
+        );
+
+        let mut button = ctx.add_with::<Button>(|b, ctx| {
+            b.fill = fill;
+            b.corner_radius = style.corner_radius;
+            b.set_child(ctx.add_with::<Pad>(|p, _ctx| {
+                *p = Pad::symmetric(style.pad_v, style.pad_h);
+                p.set_child(content_id);
+            }));
+        });
+
+        if enabled {
+            if let Some(on_click) = on_click {
+                button = button.interact_raw(on_click);
+            }
+        }
+        if let Some(on_enter) = on_enter {
+            button = button.interact_raw(on_enter);
+        }
+        if let Some(on_leave) = on_leave {
+            button = button.interact_raw(on_leave);
+        }
+
+        button.handle()
+    }
+}
+
+#[derive(Init, Element, Debug, Clone)]
+pub(crate) struct ToolIcon {
+    pub tool: Option<Tool>,
+    pub color: Brush,
+    pub size: f64,
+}
+
+impl ElementBuild for ToolIcon {
+    fn build(
+        &self,
+        _id: &ElementId,
+        constraint: Constraint,
+        _nodes: &mut ElementNodes,
+    ) -> Size {
+        constraint
+            .constrain(Size::new(self.size as f32, self.size as f32))
+    }
+
+    fn render(
+        &self,
+        id: &ElementId,
+        painter: &mut dyn PaintSink,
+        table: RenderElementTable,
+    ) {
+        use fynix::imaging::kurbo::{
+            BezPath, Circle, RoundedRect, Shape, Stroke,
+        };
+
+        let Some(node) = table.node(id) else { return };
+        let Some(tool) = self.tool else { return };
+        let pos = node.world_translation;
+        let sz = node.size;
+        let cx = (pos.x + sz.width / 2.0) as f64;
+        let cy = (pos.y + sz.height / 2.0) as f64;
+        let r = (sz.width.min(sz.height) / 2.0 - 2.0).max(2.0) as f64;
+        let stroke = Stroke::new(1.5);
+
+        match tool {
+            Tool::Select => {
+                let mut path = BezPath::new();
+                path.move_to((cx - r * 0.5, cy + r * 0.7));
+                path.line_to((cx, cy - r * 0.7));
+                path.line_to((cx + r * 0.5, cy + r * 0.7));
+                painter.stroke(StrokeRef::new(
+                    path,
+                    &Stroke::new(2.0),
+                    &self.color,
+                ));
+            }
+            Tool::Line => {
+                let mut path = BezPath::new();
+                path.move_to((cx - r * 0.6, cy + r * 0.6));
+                path.line_to((cx + r * 0.6, cy - r * 0.6));
+                painter.stroke(StrokeRef::new(
+                    path,
+                    &stroke,
+                    &self.color,
+                ));
+            }
+            Tool::Rectangle => {
+                painter.stroke(StrokeRef::new(
+                    RoundedRect::new(
+                        cx - r * 0.6,
+                        cy - r * 0.6,
+                        cx + r * 0.6,
+                        cy + r * 0.6,
+                        1.0,
+                    ),
+                    &stroke,
+                    &self.color,
+                ));
+            }
+            Tool::Circle => {
+                let path =
+                    Circle::new((cx, cy), r * 0.6).into_path(0.1);
+                painter.stroke(StrokeRef::new(
+                    path,
+                    &stroke,
+                    &self.color,
+                ));
+            }
+            Tool::Arc => {
+                let mut path = BezPath::new();
+                let l = r * 0.5;
+                path.move_to((cx - l, cy + l));
+                let k = 0.5522847498;
+                path.curve_to(
+                    (cx - l, cy + l - l * k),
+                    (cx - l + l * k, cy - l),
+                    (cx + l, cy - l),
+                );
+                painter.stroke(StrokeRef::new(
+                    path,
+                    &stroke,
+                    &self.color,
+                ));
+            }
+            Tool::Move => {
+                for (dx, dy) in [
+                    (-0.35, 0.0),
+                    (0.35, 0.0),
+                    (0.0, -0.35),
+                    (0.0, 0.35),
+                ] {
+                    let path =
+                        Circle::new((cx + dx * r, cy + dy * r), 2.0)
+                            .into_path(0.1);
+                    painter.fill(FillRef::new(path, &self.color));
+                }
+            }
+            Tool::Erase => {
+                let inner_r = r * 0.55;
+                painter.stroke(StrokeRef::new(
+                    RoundedRect::new(
+                        cx - inner_r,
+                        cy - inner_r,
+                        cx + inner_r,
+                        cy + inner_r,
+                        1.0,
+                    ),
+                    &stroke,
+                    &self.color,
+                ));
+                painter.stroke(StrokeRef::new(
+                    {
+                        let mut p = BezPath::new();
+                        p.move_to((cx - inner_r, cy - inner_r));
+                        p.line_to((cx + inner_r, cy + inner_r));
+                        p
+                    },
+                    &Stroke::new(1.0),
+                    &self.color,
+                ));
+                painter.stroke(StrokeRef::new(
+                    {
+                        let mut p = BezPath::new();
+                        p.move_to((cx + inner_r, cy - inner_r));
+                        p.line_to((cx - inner_r, cy + inner_r));
+                        p
+                    },
+                    &Stroke::new(1.0),
+                    &self.color,
+                ));
+            }
+        }
+    }
+}
+
+pub(crate) struct ToolButton {
+    label: String,
+    is_active: bool,
+    tool: Option<Tool>,
+    on_click: Option<Handler<PrimaryClick<Mouse>, CadWorld>>,
+}
+
+impl ToolButton {
+    pub(crate) fn new(
+        label: impl Into<String>,
+        is_active: bool,
+    ) -> Self {
+        Self {
+            label: label.into(),
+            is_active,
+            tool: None,
+            on_click: None,
+        }
+    }
+
+    pub(crate) fn for_tool(tool: Tool, is_active: bool) -> Self {
+        Self {
+            label: tool.display_label().into(),
+            is_active,
+            tool: Some(tool),
+            on_click: None,
+        }
+    }
+
+    pub(crate) fn on_click(
+        mut self,
+        handler: impl HandlerFn<PrimaryClick<Mouse>, CadWorld>,
+    ) -> Self {
+        self.on_click = Some(handler.into());
+        self
+    }
+}
+
+impl Composer<CadWorld> for ToolButton {
+    type Style = IconLabelButtonStyle;
+    type Element = Button;
+
+    fn compose(
+        self,
+        _style: Self::Style,
+        ctx: &mut FynixCtx<'_, '_, CadWorld>,
+    ) -> ElementHandle<Button> {
+        let ToolButton {
+            label,
+            is_active,
+            tool,
+            on_click,
+        } = self;
+
+        let hovered_tool = ctx.world.hovered_tool;
+        let hovering = tool.is_some() && hovered_tool == tool;
+
+        let handle = ctx.compose(IconLabelButton {
+            label,
+            icon_text: None,
+            tool_icon: tool,
+            accent: tool.is_some() && is_active,
+            fill: unified_fill(is_active, hovering, true),
+            fg: unified_fg(true),
+            enabled: true,
+            on_click,
+            on_enter: tool.map(|t| {
+                Handler::new(
+                    move |_, res: &mut Response<'_, CadWorld>| {
+                        res.hovered_tool = Some(t);
+                        res.hovered_hint = Some(t.hint());
+                        res.cursor_icon = CursorIcon::Pointer;
+                    },
+                )
+            }),
+            on_leave: tool.map(|_t| {
+                Handler::new(
+                    move |_, res: &mut Response<'_, CadWorld>| {
+                        res.hovered_tool = None;
+                        res.hovered_hint = None;
+                        res.cursor_icon = CursorIcon::Default;
+                    },
+                )
+            }),
+        });
+        if let Some(t) = tool {
+            handle
+                .bind(
+                    hovered_tool_changed(hovered_tool),
+                    move |w| {
+                        let hovering = w.hovered_tool == Some(t);
+                        unified_fill(is_active, hovering, true)
+                    },
+                    |b: &mut Button| &mut b.fill,
+                )
+                .handle()
+        } else {
+            handle.handle()
+        }
+    }
+}

--- a/examples/vello_winit_examples/examples/toolbar/elements.rs
+++ b/examples/vello_winit_examples/examples/toolbar/elements.rs
@@ -176,10 +176,8 @@ impl Composer<CadWorld> for IconLabelButton {
             }));
         });
 
-        if enabled {
-            if let Some(on_click) = on_click {
-                button = button.interact_raw(on_click);
-            }
+        if enabled && let Some(on_click) = on_click {
+            button = button.interact_raw(on_click);
         }
         if let Some(on_enter) = on_enter {
             button = button.interact_raw(on_enter);

--- a/examples/vello_winit_examples/examples/toolbar/elements.rs
+++ b/examples/vello_winit_examples/examples/toolbar/elements.rs
@@ -7,11 +7,11 @@ use fynix::prelude::*;
 use fynix_elements::{Button, Frame, Horizontal, Label, Pad};
 use fynix_interaction::prelude::*;
 use vello::peniko::{Brush, Color};
-use winit::window::CursorIcon;
 
 use crate::CadWorld;
 use crate::helpers::{
-    hovered_tool_changed, unified_fg, unified_fill,
+    hovered_tool_changed, tool_enter_handler, tool_leave_handler,
+    unified_fg, unified_fill,
 };
 use crate::theme::*;
 
@@ -406,24 +406,8 @@ impl Composer<CadWorld> for ToolButton {
             fg: unified_fg(true),
             enabled: true,
             on_click,
-            on_enter: tool.map(|t| {
-                Handler::new(
-                    move |_, res: &mut Response<'_, CadWorld>| {
-                        res.hovered_tool = Some(t);
-                        res.hovered_hint = Some(t.hint());
-                        res.cursor_icon = CursorIcon::Pointer;
-                    },
-                )
-            }),
-            on_leave: tool.map(|_t| {
-                Handler::new(
-                    move |_, res: &mut Response<'_, CadWorld>| {
-                        res.hovered_tool = None;
-                        res.hovered_hint = None;
-                        res.cursor_icon = CursorIcon::Default;
-                    },
-                )
-            }),
+            on_enter: tool.map(tool_enter_handler),
+            on_leave: tool.is_some().then(tool_leave_handler),
         });
         if let Some(t) = tool {
             handle

--- a/examples/vello_winit_examples/examples/toolbar/helpers.rs
+++ b/examples/vello_winit_examples/examples/toolbar/helpers.rs
@@ -1,0 +1,153 @@
+use core::cell::Cell;
+
+use fynix::interaction::Handler;
+use fynix::prelude::*;
+use fynix_elements::{Button, Frame, Label, Pad};
+use fynix_interaction::prelude::*;
+use vello::peniko::{Brush, Color};
+
+use crate::CadWorld;
+use crate::theme::*;
+
+pub(crate) fn cell_diff<T: PartialEq + Copy>(
+    prev: &Cell<T>,
+    current: T,
+) -> bool {
+    let changed = prev.get() != current;
+    prev.set(current);
+    changed
+}
+
+pub(crate) fn add_separator(
+    ctx: &mut FynixCtx<CadWorld>,
+) -> ElementId {
+    ctx.add_with::<Frame>(|line, _| {
+        line.fill = Brush::Solid(SEPARATOR);
+        line.corner_radius = 0.0;
+        line.top = 0.5;
+        line.bottom = 0.5;
+    })
+    .id()
+}
+
+pub(crate) fn add_vertical_separator(
+    ctx: &mut FynixCtx<CadWorld>,
+) -> ElementId {
+    ctx.add_with::<Frame>(|f, _| {
+        f.fill = Brush::Solid(SEPARATOR);
+        f.corner_radius = 0.0;
+        f.top = 0.0;
+        f.bottom = 0.0;
+        f.left = 0.5;
+        f.right = 0.5;
+    })
+    .id()
+}
+
+pub(crate) fn vertical_separator(
+    ctx: &mut FynixCtx<CadWorld>,
+) -> ElementId {
+    let line = add_vertical_separator(ctx);
+
+    ctx.add_with::<Pad>(|p, _| {
+        p.top = 4.0;
+        p.bottom = 4.0;
+        p.left = 6.0;
+        p.right = 6.0;
+        p.set_child(line);
+    })
+    .id()
+}
+
+pub(crate) fn panel_frame(
+    ctx: &mut FynixCtx<CadWorld>,
+    content: ElementId,
+) -> ElementId {
+    ctx.add_with::<Frame>(|bg, _| {
+        bg.fill = Brush::Solid(PANEL_BG);
+        bg.top = GAP_V;
+        bg.bottom = GAP_V;
+        bg.left = OUTER_PAD;
+        bg.right = OUTER_PAD;
+        bg.set_child(content);
+    })
+    .id()
+}
+
+pub(crate) fn dismiss_dropdown_handler()
+-> Handler<PrimaryClick<Mouse>, CadWorld> {
+    Handler::<PrimaryClick<Mouse>, _>::new(
+        |_, res: &mut Response<'_, CadWorld>| {
+            res.expanded_dropdown = None;
+        },
+    )
+}
+
+pub(crate) fn dismiss_on_click(
+    ctx: &mut FynixCtx<CadWorld>,
+    content: ElementId,
+) -> ElementId {
+    ctx.add_with::<Button>(|b, _| {
+        b.fill = Brush::Solid(Color::TRANSPARENT);
+        b.corner_radius = 0.0;
+        b.set_child(content);
+    })
+    .interact_raw(dismiss_dropdown_handler())
+    .id()
+}
+
+pub(crate) fn hovered_tool_changed(
+    initial: Option<Tool>,
+) -> impl Fn(&CadWorld) -> bool + 'static {
+    let prev = Cell::new(initial);
+    move |w: &CadWorld| cell_diff(&prev, w.hovered_tool)
+}
+
+pub(crate) fn hint_changed(
+    world: &CadWorld,
+) -> impl Fn(&CadWorld) -> bool + 'static {
+    let prev = Cell::new(world.hovered_hint);
+    move |w: &CadWorld| cell_diff(&prev, w.hovered_hint)
+}
+
+pub(crate) fn tight_spacer(
+    ctx: &mut FynixCtx<CadWorld>,
+) -> ElementId {
+    ctx.add_with::<Pad>(|sp, _| {
+        *sp = Pad::horizontal(2.0);
+    })
+    .id()
+}
+
+pub(crate) fn header_label(
+    ctx: &mut FynixCtx<CadWorld>,
+    text: impl Into<String>,
+) -> ElementId {
+    ctx.add_with::<Label>(|l, _| {
+        l.text = text.into();
+        l.font_size = HEADER_FONT;
+        l.fill = Brush::Solid(MUTED_TEXT);
+    })
+    .id()
+}
+
+pub(crate) fn unified_fill(
+    active: bool,
+    hovered: bool,
+    enabled: bool,
+) -> Brush {
+    Brush::Solid(if !enabled {
+        DISABLED_BG
+    } else {
+        match (active, hovered) {
+            (true, true) => HOVERED_ACTIVE_BG,
+            (true, false) => ACTIVE_BG,
+            (false, true) => HOVERED_INACTIVE_BG,
+            (false, false) => INACTIVE_BG,
+        }
+    })
+}
+
+pub(crate) fn unified_fg(enabled: bool) -> Brush {
+    Brush::Solid(if enabled { Color::WHITE } else { DISABLED_TEXT })
+}

--- a/examples/vello_winit_examples/examples/toolbar/helpers.rs
+++ b/examples/vello_winit_examples/examples/toolbar/helpers.rs
@@ -5,6 +5,7 @@ use fynix::prelude::*;
 use fynix_elements::{Button, Frame, Label, Pad};
 use fynix_interaction::prelude::*;
 use vello::peniko::{Brush, Color};
+use winit::window::CursorIcon;
 
 use crate::CadWorld;
 use crate::theme::*;
@@ -22,7 +23,6 @@ pub(crate) fn add_separator(
     ctx: &mut FynixCtx<CadWorld>,
 ) -> ElementId {
     ctx.add_with::<Frame>(|line, _| {
-        line.fill = Brush::Solid(SEPARATOR);
         line.corner_radius = 0.0;
         line.top = 0.5;
         line.bottom = 0.5;
@@ -34,7 +34,6 @@ pub(crate) fn add_vertical_separator(
     ctx: &mut FynixCtx<CadWorld>,
 ) -> ElementId {
     ctx.add_with::<Frame>(|f, _| {
-        f.fill = Brush::Solid(SEPARATOR);
         f.corner_radius = 0.0;
         f.top = 0.0;
         f.bottom = 0.0;
@@ -81,6 +80,25 @@ pub(crate) fn dismiss_dropdown_handler()
             res.expanded_dropdown = None;
         },
     )
+}
+
+pub(crate) fn tool_enter_handler(
+    tool: Tool,
+) -> Handler<PointerEnter<Mouse>, CadWorld> {
+    Handler::new(move |_, res: &mut Response<'_, CadWorld>| {
+        res.hovered_tool = Some(tool);
+        res.hovered_hint = Some(tool.hint());
+        res.cursor_icon = CursorIcon::Pointer;
+    })
+}
+
+pub(crate) fn tool_leave_handler()
+-> Handler<PointerLeave<Mouse>, CadWorld> {
+    Handler::new(|_, res: &mut Response<'_, CadWorld>| {
+        res.hovered_tool = None;
+        res.hovered_hint = None;
+        res.cursor_icon = CursorIcon::Default;
+    })
 }
 
 pub(crate) fn dismiss_on_click(

--- a/examples/vello_winit_examples/examples/toolbar/main.rs
+++ b/examples/vello_winit_examples/examples/toolbar/main.rs
@@ -124,32 +124,24 @@ impl DemoWorld for CadWorld {
         let ctrl = mods.state().control_key();
         let shift = mods.state().shift_key();
 
-        if ctrl && shift {
-            if let Key::Character(ch) = &event.logical_key {
-                if ch.as_str().eq_ignore_ascii_case("z") {
-                    self.redo();
-                    return;
-                }
-            }
-        }
-
-        if ctrl {
-            if let Key::Character(ch) = &event.logical_key {
-                if ch.as_str().eq_ignore_ascii_case("z") {
-                    self.undo();
-                    return;
-                }
-            }
-        }
-
-        if !ctrl && !shift {
-            if let Some(text) = &event.text {
-                if let Some(ch) = text.chars().next() {
-                    if let Some(tool) = Tool::from_key(ch) {
-                        self.select_tool(tool);
-                    }
-                }
-            }
+        if ctrl
+            && shift
+            && let Key::Character(ch) = &event.logical_key
+            && ch.as_str().eq_ignore_ascii_case("z")
+        {
+            self.redo();
+        } else if ctrl
+            && let Key::Character(ch) = &event.logical_key
+            && ch.as_str().eq_ignore_ascii_case("z")
+        {
+            self.undo();
+        } else if !ctrl
+            && !shift
+            && let Some(text) = &event.text
+            && let Some(ch) = text.chars().next()
+            && let Some(tool) = Tool::from_key(ch)
+        {
+            self.select_tool(tool);
         }
     }
 

--- a/examples/vello_winit_examples/examples/toolbar/main.rs
+++ b/examples/vello_winit_examples/examples/toolbar/main.rs
@@ -1,0 +1,185 @@
+mod builders;
+mod elements;
+mod helpers;
+mod theme;
+
+use core::cell::Cell;
+use std::sync::Arc;
+use std::time::Duration;
+
+use fynix::prelude::*;
+use fynix_elements::parley::fontique::{Blob, GenericFamily};
+use fynix_elements::{TextContext, Viewport, WindowSize};
+use helpers::cell_diff;
+use theme::{DropdownId, Tool, ToolbarState};
+use vello_winit_examples::{DemoWorld, VelloWinitApp};
+use winit::event::{KeyEvent, Modifiers};
+use winit::event_loop::EventLoop;
+use winit::keyboard::{Key, NamedKey};
+use winit::window::CursorIcon;
+
+#[derive(Default)]
+pub(crate) struct CadWorld {
+    pub(crate) active_tool: Tool,
+    pub(crate) expanded_dropdown: Option<DropdownId>,
+    pub(crate) undo_stack: Vec<ToolbarState>,
+    pub(crate) redo_stack: Vec<ToolbarState>,
+    pub(crate) window_size: Size,
+    pub(crate) hovered_tool: Option<Tool>,
+    pub(crate) snap_enabled: bool,
+    pub(crate) grid_enabled: bool,
+    pub(crate) ortho_enabled: bool,
+    pub(crate) undo_hovered: bool,
+    pub(crate) redo_hovered: bool,
+    pub(crate) hovered_hint: Option<&'static str>,
+    pub(crate) cursor_icon: CursorIcon,
+}
+
+impl CadWorld {
+    fn snapshot(&self) -> ToolbarState {
+        ToolbarState {
+            active_tool: self.active_tool,
+            snap_enabled: self.snap_enabled,
+            grid_enabled: self.grid_enabled,
+            ortho_enabled: self.ortho_enabled,
+            expanded_dropdown: self.expanded_dropdown,
+        }
+    }
+
+    fn apply(&mut self, state: ToolbarState) {
+        self.active_tool = state.active_tool;
+        self.snap_enabled = state.snap_enabled;
+        self.grid_enabled = state.grid_enabled;
+        self.ortho_enabled = state.ortho_enabled;
+        self.expanded_dropdown = state.expanded_dropdown;
+    }
+
+    pub(crate) fn push_undo_state(&mut self) {
+        self.undo_stack.push(self.snapshot());
+        self.redo_stack.clear();
+    }
+
+    pub(crate) fn select_tool(&mut self, tool: Tool) {
+        self.push_undo_state();
+        self.active_tool = tool;
+        self.expanded_dropdown = None;
+    }
+
+    pub(crate) fn undo(&mut self) {
+        let Some(prev) = self.undo_stack.pop() else {
+            return;
+        };
+        self.redo_stack.push(self.snapshot());
+        self.apply(prev);
+    }
+
+    pub(crate) fn redo(&mut self) {
+        let Some(next) = self.redo_stack.pop() else {
+            return;
+        };
+        self.undo_stack.push(self.snapshot());
+        self.apply(next);
+    }
+}
+
+fn main() {
+    let event_loop = EventLoop::new().unwrap();
+    let mut app = VelloWinitApp::new(CadWorld::default());
+    event_loop.run_app(&mut app).unwrap();
+}
+
+impl DemoWorld for CadWorld {
+    fn window_title(&self) -> &'static str {
+        "Fynix CAD Toolbar Example"
+    }
+
+    fn initial_logical_size(&self) -> (f64, f64) {
+        (1100.0, 600.0)
+    }
+
+    fn init(&mut self, fynix: &mut Fynix<Self>) {
+        fynix_elements::init_resources(fynix);
+        let initial_size = self.initial_logical_size();
+        fynix.resources.insert(Viewport {
+            width: initial_size.0 as f32,
+            height: initial_size.1 as f32,
+        });
+
+        if let Some(text_cx) =
+            fynix.resources.get_mut::<TextContext>()
+        {
+            let blob = Blob::new(Arc::new(theme::FONT));
+            let ids =
+                text_cx.font_cx.collection.register_fonts(blob, None);
+            text_cx.font_cx.collection.set_generic_families(
+                GenericFamily::SansSerif,
+                ids.into_iter().map(|(f, _)| f),
+            );
+        }
+    }
+
+    fn on_keyboard(&mut self, event: &KeyEvent, mods: &Modifiers) {
+        if event.logical_key == Key::Named(NamedKey::Escape)
+            && self.expanded_dropdown.is_some()
+        {
+            self.expanded_dropdown = None;
+            return;
+        }
+
+        let ctrl = mods.state().control_key();
+        let shift = mods.state().shift_key();
+
+        if ctrl && shift {
+            if let Key::Character(ch) = &event.logical_key {
+                if ch.as_str().eq_ignore_ascii_case("z") {
+                    self.redo();
+                    return;
+                }
+            }
+        }
+
+        if ctrl {
+            if let Key::Character(ch) = &event.logical_key {
+                if ch.as_str().eq_ignore_ascii_case("z") {
+                    self.undo();
+                    return;
+                }
+            }
+        }
+
+        if !ctrl && !shift {
+            if let Some(text) = &event.text {
+                if let Some(ch) = text.chars().next() {
+                    if let Some(tool) = Tool::from_key(ch) {
+                        self.select_tool(tool);
+                    }
+                }
+            }
+        }
+    }
+
+    fn update(&mut self, _dt: Duration) {}
+
+    fn cursor(&self) -> CursorIcon {
+        self.cursor_icon
+    }
+
+    fn set_window_size(&mut self, size: Size) {
+        self.window_size = size;
+    }
+
+    fn build(ctx: &mut FynixCtx<Self>) -> ElementId {
+        let size = ctx.world.window_size;
+        let prev_window_size = Cell::new(size);
+        ctx.add_with::<WindowSize>(|win, ctx| {
+            win.size = size;
+            win.set_child(builders::build_app(ctx));
+        })
+        .bind(
+            move |w| cell_diff(&prev_window_size, w.window_size),
+            |w| w.window_size,
+            |win| &mut win.size,
+        )
+        .id()
+    }
+}

--- a/examples/vello_winit_examples/examples/toolbar/main.rs
+++ b/examples/vello_winit_examples/examples/toolbar/main.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use fynix::prelude::*;
 use fynix_elements::parley::fontique::{Blob, GenericFamily};
-use fynix_elements::{TextContext, Viewport, WindowSize};
+use fynix_elements::{TextContext, WindowSize};
 use helpers::cell_diff;
 use theme::{DropdownId, Tool, ToolbarState};
 use vello_winit_examples::{DemoWorld, VelloWinitApp};
@@ -99,11 +99,6 @@ impl DemoWorld for CadWorld {
 
     fn init(&mut self, fynix: &mut Fynix<Self>) {
         fynix_elements::init_resources(fynix);
-        let initial_size = self.initial_logical_size();
-        fynix.resources.insert(Viewport {
-            width: initial_size.0 as f32,
-            height: initial_size.1 as f32,
-        });
 
         if let Some(text_cx) =
             fynix.resources.get_mut::<TextContext>()

--- a/examples/vello_winit_examples/examples/toolbar/theme.rs
+++ b/examples/vello_winit_examples/examples/toolbar/theme.rs
@@ -121,6 +121,7 @@ pub(crate) fn apply_base(ctx: &mut FynixCtx<CadWorld>) {
     ctx.set(path!(<Button>::corner_radius), CORNER_RADIUS);
     ctx.set(path!(<Button>::stroke), Stroke::new(0.0));
     ctx.set(path!(<Frame>::corner_radius), CORNER_RADIUS);
+    ctx.set(path!(<Frame>::fill), Brush::Solid(SEPARATOR));
 }
 
 pub(crate) fn apply_menu_bar(ctx: &mut FynixCtx<CadWorld>) {

--- a/examples/vello_winit_examples/examples/toolbar/theme.rs
+++ b/examples/vello_winit_examples/examples/toolbar/theme.rs
@@ -1,0 +1,136 @@
+use fynix::imaging::kurbo::Stroke;
+use fynix::prelude::*;
+use fynix_elements::{Button, Frame, Label};
+use fynix_interaction::prelude::PointerId;
+use vello::peniko::color::palette::css;
+use vello::peniko::{Brush, Color};
+
+use crate::CadWorld;
+
+pub(crate) const FONT: &[u8] =
+    include_bytes!("../../assets/Inter-Regular.ttf");
+
+pub(crate) mod colors {
+    use super::{Color, css};
+
+    pub(crate) const PANEL_BG: Color = Color::from_rgb8(45, 45, 48);
+    pub(crate) const INACTIVE_BG: Color =
+        Color::from_rgb8(58, 58, 62);
+    pub(crate) const DISABLED_BG: Color =
+        Color::from_rgb8(40, 40, 43);
+    pub(crate) const HOVERED_INACTIVE_BG: Color =
+        Color::from_rgb8(74, 74, 78);
+    pub(crate) const SEPARATOR: Color = Color::from_rgb8(62, 62, 66);
+    pub(crate) const ACTIVE_BG: Color = css::CORNFLOWER_BLUE;
+    pub(crate) const HOVERED_ACTIVE_BG: Color =
+        Color::from_rgb8(130, 179, 255);
+    pub(crate) const ACCENT: Color = css::CORNFLOWER_BLUE;
+    pub(crate) const MUTED_TEXT: Color = css::DIM_GRAY;
+    pub(crate) const DISABLED_TEXT: Color = css::GRAY;
+}
+
+pub(crate) mod metrics {
+    pub const CORNER_RADIUS: f64 = 4.0;
+    pub const FONT_SIZE: f32 = 12.0;
+    pub const HEADER_FONT: f32 = 10.0;
+    pub const PAD_V: f32 = 8.0;
+    pub const PAD_H: f32 = 10.0;
+    pub const GAP: f32 = 8.0;
+    pub const OUTER_PAD: f32 = 8.0;
+    pub const GAP_V: f32 = 6.0;
+}
+
+pub(crate) use colors::*;
+pub(crate) use metrics::*;
+
+pub(crate) const DRAW_TOOLS: &[Tool] =
+    &[Tool::Line, Tool::Rectangle, Tool::Circle, Tool::Arc];
+
+pub(crate) const MODIFY_TOOLS: &[Tool] = &[Tool::Move, Tool::Erase];
+
+pub(crate) type Mouse = PointerId<(), ()>;
+
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+pub(crate) enum Tool {
+    #[default]
+    Select,
+    Line,
+    Rectangle,
+    Circle,
+    Arc,
+    Move,
+    Erase,
+}
+
+impl Tool {
+    pub(crate) fn display_label(&self) -> &'static str {
+        match self {
+            Tool::Select => "Select (S)",
+            Tool::Line => "Line (L)",
+            Tool::Rectangle => "Rect",
+            Tool::Circle => "Circle",
+            Tool::Arc => "Arc",
+            Tool::Move => "Move (M)",
+            Tool::Erase => "Erase",
+        }
+    }
+
+    pub(crate) fn hint(&self) -> &'static str {
+        match self {
+            Tool::Select => "Select, move, and modify objects",
+            Tool::Line => "Click to place start point of a line",
+            Tool::Rectangle => "Click to place a rectangle",
+            Tool::Circle => "Click to place a circle",
+            Tool::Arc => "Click to place an arc",
+            Tool::Move => "Click to move selected objects",
+            Tool::Erase => "Click to erase objects",
+        }
+    }
+
+    pub(crate) fn from_key(ch: char) -> Option<Tool> {
+        match ch.to_ascii_lowercase() {
+            's' => Some(Tool::Select),
+            'l' => Some(Tool::Line),
+            'r' => Some(Tool::Rectangle),
+            'c' => Some(Tool::Circle),
+            'a' => Some(Tool::Arc),
+            'm' => Some(Tool::Move),
+            'e' => Some(Tool::Erase),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+pub(crate) struct ToolbarState {
+    pub active_tool: Tool,
+    pub snap_enabled: bool,
+    pub grid_enabled: bool,
+    pub ortho_enabled: bool,
+    pub expanded_dropdown: Option<DropdownId>,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+pub(crate) enum DropdownId {
+    Draw,
+    Modify,
+}
+
+pub(crate) fn apply_base(ctx: &mut FynixCtx<CadWorld>) {
+    ctx.set(path!(<Label>::font_size), FONT_SIZE);
+    ctx.set(path!(<Button>::corner_radius), CORNER_RADIUS);
+    ctx.set(path!(<Button>::stroke), Stroke::new(0.0));
+    ctx.set(path!(<Frame>::corner_radius), CORNER_RADIUS);
+}
+
+pub(crate) fn apply_menu_bar(ctx: &mut FynixCtx<CadWorld>) {
+    ctx.set(path!(<Label>::font_size), HEADER_FONT);
+    ctx.set(path!(<Label>::fill), Brush::Solid(MUTED_TEXT));
+    ctx.set(path!(<Button>::fill), Brush::Solid(Color::TRANSPARENT));
+    ctx.set(path!(<Button>::corner_radius), 0.0);
+    ctx.set(path!(<Button>::stroke), Stroke::new(0.0));
+}
+
+pub(crate) fn apply_toolbar_toggle(ctx: &mut FynixCtx<CadWorld>) {
+    ctx.set(path!(<Button>::corner_radius), 3.0);
+}

--- a/examples/vello_winit_examples/src/lib.rs
+++ b/examples/vello_winit_examples/src/lib.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use fynix::prelude::*;
-use fynix_elements::Viewport;
 use fynix_interaction::pointer;
 use fynix_interaction::prelude::*;
 use imaging_vello::VelloSceneSink;
@@ -331,12 +330,6 @@ impl<D: DemoWorld> ApplicationHandler for VelloWinitApp<'_, D> {
                     logical.width,
                     logical.height,
                 ));
-                if let Some(vp) =
-                    self.fynix.resources.get_mut::<Viewport>()
-                {
-                    vp.width = logical.width;
-                    vp.height = logical.height;
-                }
                 self.render();
             }
             WindowEvent::ScaleFactorChanged {

--- a/examples/vello_winit_examples/src/lib.rs
+++ b/examples/vello_winit_examples/src/lib.rs
@@ -14,7 +14,9 @@ use vello::{
 };
 use winit::application::ApplicationHandler;
 use winit::dpi::LogicalSize;
-use winit::event::{ElementState, MouseButton, WindowEvent};
+use winit::event::{
+    ElementState, KeyEvent, Modifiers, MouseButton, WindowEvent,
+};
 use winit::event_loop::ActiveEventLoop;
 use winit::window::{CursorIcon, Window};
 
@@ -63,6 +65,10 @@ pub trait DemoWorld: Sized + 'static {
     fn cursor(&self) -> CursorIcon {
         CursorIcon::default()
     }
+
+    /// Called when a keyboard key is pressed. Override to handle
+    /// keyboard shortcuts. The default does nothing.
+    fn on_keyboard(&mut self, _event: &KeyEvent, _mods: &Modifiers) {}
 }
 
 pub struct VelloWinitApp<'s, W: DemoWorld> {
@@ -71,6 +77,8 @@ pub struct VelloWinitApp<'s, W: DemoWorld> {
     root_id: ElementId,
     interactor: Interactor<(), (), MouseButton>,
     cursor: Point,
+    /// Tracks keyboard modifiers for dispatching to the world.
+    modifiers: Modifiers,
     /// Physical-pixels-per-logical-pixel, from the window.
     scale_factor: f64,
     last_frame: Instant,
@@ -116,6 +124,7 @@ impl<W: DemoWorld> VelloWinitApp<'_, W> {
             world,
             interactor,
             cursor: Point::ZERO,
+            modifiers: Modifiers::default(),
             scale_factor: 1.0,
             last_frame: Instant::now(),
             context: RenderContext::new(),
@@ -354,6 +363,15 @@ impl<D: DemoWorld> ApplicationHandler for VelloWinitApp<'_, D> {
                         self.cursor,
                     ),
                 }
+            }
+            WindowEvent::KeyboardInput { event, .. } => {
+                if event.state == ElementState::Pressed {
+                    self.world.on_keyboard(&event, &self.modifiers);
+                    self.render();
+                }
+            }
+            WindowEvent::ModifiersChanged(mods) => {
+                self.modifiers = mods;
             }
             _ => {}
         }

--- a/examples/vello_winit_examples/src/lib.rs
+++ b/examples/vello_winit_examples/src/lib.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use fynix::prelude::*;
+use fynix_elements::Viewport;
 use fynix_interaction::pointer;
 use fynix_interaction::prelude::*;
 use imaging_vello::VelloSceneSink;
@@ -330,6 +331,12 @@ impl<D: DemoWorld> ApplicationHandler for VelloWinitApp<'_, D> {
                     logical.width,
                     logical.height,
                 ));
+                if let Some(vp) =
+                    self.fynix.resources.get_mut::<Viewport>()
+                {
+                    vp.width = logical.width;
+                    vp.height = logical.height;
+                }
                 self.render();
             }
             WindowEvent::ScaleFactorChanged {

--- a/examples/vello_winit_examples/src/lib.rs
+++ b/examples/vello_winit_examples/src/lib.rs
@@ -6,7 +6,7 @@ use fynix::prelude::*;
 use fynix_interaction::pointer;
 use fynix_interaction::prelude::*;
 use imaging_vello::VelloSceneSink;
-use vello::kurbo::{Point, Rect};
+use vello::kurbo::{Affine, Point, Rect};
 use vello::peniko::Color;
 use vello::util::{RenderContext, RenderSurface};
 use vello::{
@@ -71,10 +71,14 @@ pub struct VelloWinitApp<'s, W: DemoWorld> {
     root_id: ElementId,
     interactor: Interactor<(), (), MouseButton>,
     cursor: Point,
+    /// Physical-pixels-per-logical-pixel, from the window.
+    scale_factor: f64,
     last_frame: Instant,
     context: RenderContext,
     renderer: Option<Renderer>,
     state: RenderState<'s>,
+    /// The UI scene in logical coordinates, scaled into `scene`.
+    ui_scene: Scene,
     scene: Scene,
 }
 
@@ -112,10 +116,12 @@ impl<W: DemoWorld> VelloWinitApp<'_, W> {
             world,
             interactor,
             cursor: Point::ZERO,
+            scale_factor: 1.0,
             last_frame: Instant::now(),
             context: RenderContext::new(),
             renderer: None,
             state: RenderState::Suspended(None),
+            ui_scene: Scene::new(),
             scene: Scene::new(),
         }
     }
@@ -158,15 +164,24 @@ impl<W: DemoWorld> VelloWinitApp<'_, W> {
         // the fresh layout on the next pointer event.
         self.interactor.invalidate();
 
+        // Render the UI in logical coordinates, then scale it into
+        // the physical-pixel scene so it fills the surface at any
+        // DPI.
         let bounds = Rect::new(
             0.0,
             0.0,
-            phys.width as f64,
-            phys.height as f64,
+            phys.width as f64 / self.scale_factor,
+            phys.height as f64 / self.scale_factor,
         );
-        let mut sink = VelloSceneSink::new(&mut self.scene, bounds);
+        self.ui_scene.reset();
+        let mut sink =
+            VelloSceneSink::new(&mut self.ui_scene, bounds);
         self.fynix.render(&self.root_id, &mut sink);
         sink.finish().unwrap();
+        self.scene.append(
+            &self.ui_scene,
+            Some(Affine::scale(self.scale_factor)),
+        );
 
         let dev = &self.context.devices[surface.dev_id];
         let texture = match surface.surface.get_current_texture() {
@@ -237,6 +252,8 @@ impl<D: DemoWorld> ApplicationHandler for VelloWinitApp<'_, D> {
             Arc::new(event_loop.create_window(attr).unwrap())
         });
 
+        self.scale_factor = window.scale_factor();
+
         let phys = window.inner_size();
         let surface_future = self.context.create_surface(
             window.clone(),
@@ -298,13 +315,23 @@ impl<D: DemoWorld> ApplicationHandler for VelloWinitApp<'_, D> {
                 }
             }
             WindowEvent::Resized(phys) => {
-                let size =
-                    Size::new(phys.width as f32, phys.height as f32);
-                self.world.set_window_size(size);
+                let logical =
+                    phys.to_logical::<f32>(self.scale_factor);
+                self.world.set_window_size(Size::new(
+                    logical.width,
+                    logical.height,
+                ));
                 self.render();
             }
+            WindowEvent::ScaleFactorChanged {
+                scale_factor, ..
+            } => {
+                self.scale_factor = scale_factor;
+            }
             WindowEvent::CursorMoved { position, .. } => {
-                self.cursor = Point::new(position.x, position.y);
+                let pos =
+                    position.to_logical::<f64>(self.scale_factor);
+                self.cursor = Point::new(pos.x, pos.y);
                 self.interactor.moved(
                     &mut self.fynix,
                     &mut self.world,


### PR DESCRIPTION
Resolve #26 

# New Elements (`fynix_elements`)

## Frame

A decorative container that wraps a single child with: (Frame draws a background fill with rounded corners around its child; Pad is invisible spacing only.)

- Background fill
- Rounded corners
- Per-side insets

Handles the common pattern of drawing a filled rounded rectangle behind content.

## Overlay

A positioning container designed for popups, tooltips, and dropdowns. Overlay walks up the parent tree from the anchor element to compute its absolute position, then places its content at that spot.

Features:

- Anchor-based positioning (place relative to any child element)
- Automatic flip on overflow (switches to the opposite side when content does not fit)
- Viewport clamping
- Configurable side, gap, alignment, and offset

---

# New Example: CAD Toolbar

Added a comprehensive CAD toolbar example demonstrating Fynix's UI capabilities:

- Style rules
- Reactive bindings
- Composable elements:
  - `ToolButton`
  - `IconLabelButton`
  - `MenuBarItem`
- New `Frame` and `Overlay` elements

## Features Demonstrated

- Tool palette with:
  - Selection tools
  - Drawing tools
  - Modification tools
- Undo/redo stack
- Dropdown panels anchored to toolbar buttons
- Toggle flags:
  - Snap
  - Grid
  - Ortho
- Status bar with hover hints
- Keyboard shortcuts